### PR TITLE
feat(kag): add comprehensive error handling with retry logic and status dashboard

### DIFF
--- a/internal/kb/provider_ollama.go
+++ b/internal/kb/provider_ollama.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -195,8 +196,192 @@ type ollamaGenerateResponse struct {
 	EvalCount          int    `json:"eval_count"`
 }
 
+// sanitizeJSONString cleans up common LLM JSON quirks before parsing.
+// Handles invalid escape sequences like \_ (LaTeX-style) that break JSON parsers.
+func sanitizeJSONString(s string) string {
+	// Replace common invalid escape sequences
+	// \_ is common in LaTeX-style text (e.g., "machine\_learning")
+	result := strings.ReplaceAll(s, "\\_", "_")
+	// \* for emphasis markers
+	result = strings.ReplaceAll(result, "\\*", "*")
+	// \# for headers
+	result = strings.ReplaceAll(result, "\\#", "#")
+	// \[ and \] for math notation
+	result = strings.ReplaceAll(result, "\\[", "[")
+	result = strings.ReplaceAll(result, "\\]", "]")
+	return result
+}
+
+// salvageIncompleteJSON attempts to recover valid data from truncated JSON.
+// It tries to extract entities even if the relations section is incomplete.
+func salvageIncompleteJSON(jsonStr string) ([]ExtractedEntity, error) {
+	// Try to find and parse just the entities array
+	entitiesStart := strings.Index(jsonStr, `"entities"`)
+	if entitiesStart == -1 {
+		return nil, fmt.Errorf("no entities field found")
+	}
+
+	// Find the start of the entities array
+	arrayStart := strings.Index(jsonStr[entitiesStart:], "[")
+	if arrayStart == -1 {
+		return nil, fmt.Errorf("no entities array found")
+	}
+	arrayStart += entitiesStart
+
+	// Try to find the end of entities array
+	depth := 0
+	arrayEnd := -1
+	inString := false
+	escaped := false
+
+	for i := arrayStart; i < len(jsonStr); i++ {
+		c := jsonStr[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		if c == '[' {
+			depth++
+		} else if c == ']' {
+			depth--
+			if depth == 0 {
+				arrayEnd = i
+				break
+			}
+		}
+	}
+
+	if arrayEnd == -1 {
+		// Array is incomplete - try to salvage by closing it
+		// Find the last complete object
+		lastObjEnd := strings.LastIndex(jsonStr, "}")
+		if lastObjEnd > arrayStart {
+			jsonStr = jsonStr[:lastObjEnd+1] + "]"
+			arrayEnd = len(jsonStr) - 1
+		} else {
+			return nil, fmt.Errorf("cannot salvage entities array")
+		}
+	}
+
+	entitiesJSON := jsonStr[arrayStart : arrayEnd+1]
+
+	// Parse as flexible entities
+	var entities []flexibleEntity
+	if err := json.Unmarshal([]byte(entitiesJSON), &entities); err != nil {
+		return nil, fmt.Errorf("salvage parse failed: %w", err)
+	}
+
+	// Convert to ExtractedEntity
+	result := make([]ExtractedEntity, 0, len(entities))
+	for _, fe := range entities {
+		e := fe.toExtractedEntity()
+		if e.Name != "" {
+			result = append(result, e)
+		}
+	}
+
+	return result, nil
+}
+
+// flexibleEntity handles JSON with type mismatches (e.g., arrays instead of strings).
+type flexibleEntity struct {
+	Name        interface{} `json:"name"`
+	Type        interface{} `json:"type"`
+	Description interface{} `json:"description"`
+	Confidence  interface{} `json:"confidence"`
+}
+
+// toExtractedEntity converts flexible entity to ExtractedEntity, coercing types.
+func (fe *flexibleEntity) toExtractedEntity() ExtractedEntity {
+	return ExtractedEntity{
+		Name:        coerceToString(fe.Name),
+		Type:        coerceToString(fe.Type),
+		Description: coerceToString(fe.Description),
+		Confidence:  coerceToFloat(fe.Confidence),
+	}
+}
+
+// flexibleRelation handles JSON with type mismatches for relations.
+type flexibleRelation struct {
+	Subject    interface{} `json:"subject"`
+	Predicate  interface{} `json:"predicate"`
+	Object     interface{} `json:"object"`
+	Confidence interface{} `json:"confidence"`
+}
+
+// toExtractedRelation converts flexible relation to ExtractedRelation.
+func (fr *flexibleRelation) toExtractedRelation() ExtractedRelation {
+	return ExtractedRelation{
+		Subject:    coerceToString(fr.Subject),
+		Predicate:  coerceToString(fr.Predicate),
+		Object:     coerceToString(fr.Object),
+		Confidence: coerceToFloat(fr.Confidence),
+	}
+}
+
+// coerceToString converts various types to string, joining arrays with ", ".
+func coerceToString(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	switch val := v.(type) {
+	case string:
+		return val
+	case []interface{}:
+		// Join array elements with comma
+		parts := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, ", ")
+	case float64:
+		return fmt.Sprintf("%.0f", val)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+// coerceToFloat converts various types to float64.
+func coerceToFloat(v interface{}) float64 {
+	if v == nil {
+		return 0.8 // Default confidence
+	}
+	switch val := v.(type) {
+	case float64:
+		return val
+	case string:
+		// Try to parse string as float
+		var f float64
+		if _, err := fmt.Sscanf(val, "%f", &f); err == nil {
+			return f
+		}
+		return 0.8
+	case int:
+		return float64(val)
+	default:
+		return 0.8
+	}
+}
+
 // parseExtractionResponse parses the LLM JSON response into entities and relations.
+// Uses a multi-stage approach: sanitize → try parse → on fail: salvage → flexible unmarshal.
 func parseExtractionResponse(response string) (*ExtractionResponse, error) {
+	// Stage 1: Sanitize common LLM JSON quirks
+	response = sanitizeJSONString(response)
+
 	// Find JSON in response (LLM might include preamble)
 	jsonStart := findJSONStart(response)
 	if jsonStart == -1 {
@@ -207,23 +392,55 @@ func parseExtractionResponse(response string) (*ExtractionResponse, error) {
 	// Find matching closing brace
 	jsonEnd := findJSONEnd(jsonStr)
 	if jsonEnd == -1 {
-		return nil, fmt.Errorf("incomplete JSON in response")
+		// Stage 2: Try to salvage incomplete JSON
+		entities, err := salvageIncompleteJSON(jsonStr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrIncompleteJSON, err)
+		}
+		// Successfully salvaged entities
+		validEntities := make([]ExtractedEntity, 0, len(entities))
+		for _, e := range entities {
+			e.Type = normalizeEntityType(e.Type)
+			if err := e.Validate(); err == nil {
+				validEntities = append(validEntities, e)
+			}
+		}
+		return &ExtractionResponse{
+			Entities:  validEntities,
+			Relations: []ExtractedRelation{}, // Relations lost in truncation
+		}, nil
 	}
 	jsonStr = jsonStr[:jsonEnd+1]
 
-	// Parse JSON
-	var raw struct {
-		Entities  []ExtractedEntity  `json:"entities"`
-		Relations []ExtractedRelation `json:"relations"`
+	// Stage 3: Try flexible unmarshaling first (handles type mismatches)
+	var rawFlex struct {
+		Entities  []flexibleEntity   `json:"entities"`
+		Relations []flexibleRelation `json:"relations"`
 	}
 
-	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
-		return nil, fmt.Errorf("parse JSON: %w", err)
+	if err := json.Unmarshal([]byte(jsonStr), &rawFlex); err != nil {
+		// Stage 4: If flexible unmarshal fails, try salvage
+		entities, salvageErr := salvageIncompleteJSON(jsonStr)
+		if salvageErr != nil {
+			return nil, fmt.Errorf("parse JSON: %w", err)
+		}
+		validEntities := make([]ExtractedEntity, 0, len(entities))
+		for _, e := range entities {
+			e.Type = normalizeEntityType(e.Type)
+			if err := e.Validate(); err == nil {
+				validEntities = append(validEntities, e)
+			}
+		}
+		return &ExtractionResponse{
+			Entities:  validEntities,
+			Relations: []ExtractedRelation{},
+		}, nil
 	}
 
-	// Validate and normalize entities
-	validEntities := make([]ExtractedEntity, 0, len(raw.Entities))
-	for _, e := range raw.Entities {
+	// Convert flexible entities to standard entities
+	validEntities := make([]ExtractedEntity, 0, len(rawFlex.Entities))
+	for _, fe := range rawFlex.Entities {
+		e := fe.toExtractedEntity()
 		// Normalize entity type
 		e.Type = normalizeEntityType(e.Type)
 		if err := e.Validate(); err == nil {
@@ -231,9 +448,10 @@ func parseExtractionResponse(response string) (*ExtractionResponse, error) {
 		}
 	}
 
-	// Validate and normalize relations
-	validRelations := make([]ExtractedRelation, 0, len(raw.Relations))
-	for _, r := range raw.Relations {
+	// Convert flexible relations to standard relations
+	validRelations := make([]ExtractedRelation, 0, len(rawFlex.Relations))
+	for _, fr := range rawFlex.Relations {
+		r := fr.toExtractedRelation()
 		// Normalize predicate
 		r.Predicate = normalizeRelationType(r.Predicate)
 		if err := r.Validate(); err == nil {


### PR DESCRIPTION
## Summary

Implements a comprehensive 5-part error handling solution for KAG entity extraction:

- **Parser Resilience**: Multi-stage JSON parsing with escape sanitization, incomplete response salvaging, and type coercion
- **Automatic Retry**: Exponential backoff (1s, 2s, 4s...) with default 2 attempts, configurable up to 5
- **Manual Retry Command**: `conduit kb kag-retry` with `--chunk-id`, `--max-retries`, `--dry-run` flags
- **KAG Status Dashboard**: `conduit kb kag-status` with progress bar, error breakdown, system resources, Ollama status
- **Enhanced Sync Summary**: Error type breakdown and retry hints after kag-sync completes

## Test plan

- [ ] Run `go build -tags "fts5" ./...` - verify build compiles
- [ ] Run `go test -tags "fts5" ./internal/kb/...` - verify all tests pass
- [ ] Test parser handles incomplete JSON (salvages entities)
- [ ] Test parser handles `\_` escape sequences
- [ ] Test parser coerces arrays to strings
- [ ] Test `conduit kb kag-retry --dry-run` shows preview
- [ ] Test `conduit kb kag-status` shows progress bar and stats
- [ ] Test sync summary shows error breakdown when errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)