### PR TITLE
fix(branding): Update app ID to correct reverse domain notation

### DIFF
--- a/apps/conduit-desktop/electron-builder.yml
+++ b/apps/conduit-desktop/electron-builder.yml
@@ -1,7 +1,7 @@
 # Conduit Desktop - Electron Builder Configuration
 # https://www.electron.build/configuration
 
-appId: com.simpleflo.conduit
+appId: dev.simpleflo.conduit
 productName: Conduit
 copyright: Copyright © 2026 Simpleflo
 

--- a/apps/conduit-desktop/src/main/index.ts
+++ b/apps/conduit-desktop/src/main/index.ts
@@ -44,7 +44,7 @@ function createWindow(): void {
 }
 
 app.whenReady().then(() => {
-  electronApp.setAppUserModelId('com.simpleflo.conduit')
+  electronApp.setAppUserModelId('dev.simpleflo.conduit')
 
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)

--- a/apps/conduit-desktop/src/main/menu.ts
+++ b/apps/conduit-desktop/src/main/menu.ts
@@ -129,13 +129,13 @@ export function createApplicationMenu(): void {
         {
           label: 'Documentation',
           click: async (): Promise<void> => {
-            await shell.openExternal('https://github.com/simpleflo/conduit')
+            await shell.openExternal('https://conduit.simpleflo.dev')
           }
         },
         {
           label: 'Report Issue',
           click: async (): Promise<void> => {
-            await shell.openExternal('https://github.com/simpleflo/conduit/issues')
+            await shell.openExternal('https://github.com/amlandas/Conduit-AI-Intelligence-Hub/issues')
           }
         }
       ]

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -3495,7 +3495,7 @@ func serviceStartCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch runtime.GOOS {
 			case "darwin":
-				return exec.Command("launchctl", "start", "com.simpleflo.conduit").Run()
+				return exec.Command("launchctl", "start", "dev.simpleflo.conduit").Run()
 			case "linux":
 				return exec.Command("systemctl", "--user", "start", "conduit").Run()
 			default:
@@ -3534,7 +3534,7 @@ func serviceStatusCmd() *cobra.Command {
 			switch runtime.GOOS {
 			case "darwin":
 				homeDir, _ := os.UserHomeDir()
-				plistPath := filepath.Join(homeDir, "Library", "LaunchAgents", "com.simpleflo.conduit.plist")
+				plistPath := filepath.Join(homeDir, "Library", "LaunchAgents", "dev.simpleflo.conduit.plist")
 				if _, err := os.Stat(plistPath); err == nil {
 					fmt.Println("✓ Daemon service is installed (launchd)")
 				} else {

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -354,7 +354,7 @@ sudo systemctl start conduit@$USER
 
 ### Custom launchd Service (macOS)
 
-If you need custom service configuration, create `~/Library/LaunchAgents/com.simpleflo.conduit.plist`:
+If you need custom service configuration, create `~/Library/LaunchAgents/dev.simpleflo.conduit.plist`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -363,7 +363,7 @@ If you need custom service configuration, create `~/Library/LaunchAgents/com.sim
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.simpleflo.conduit</string>
+    <string>dev.simpleflo.conduit</string>
     <key>ProgramArguments</key>
     <array>
         <string>/usr/local/bin/conduit-daemon</string>
@@ -383,7 +383,7 @@ If you need custom service configuration, create `~/Library/LaunchAgents/com.sim
 
 Load and start:
 ```bash
-launchctl load ~/Library/LaunchAgents/com.simpleflo.conduit.plist
+launchctl load ~/Library/LaunchAgents/dev.simpleflo.conduit.plist
 ```
 
 **Note**: The `conduit service install` command creates this file automatically.
@@ -1275,8 +1275,8 @@ conduit service remove
 
 # Or if service commands aren't available:
 # macOS
-launchctl unload ~/Library/LaunchAgents/com.simpleflo.conduit.plist
-rm ~/Library/LaunchAgents/com.simpleflo.conduit.plist
+launchctl unload ~/Library/LaunchAgents/dev.simpleflo.conduit.plist
+rm ~/Library/LaunchAgents/dev.simpleflo.conduit.plist
 
 # Linux
 systemctl --user stop conduit

--- a/docs/CLI_COMMAND_INDEX.md
+++ b/docs/CLI_COMMAND_INDEX.md
@@ -127,7 +127,7 @@ conduit service install
 ```
 
 **Platform-specific locations**:
-- **macOS**: `~/Library/LaunchAgents/com.simpleflo.conduit.plist`
+- **macOS**: `~/Library/LaunchAgents/dev.simpleflo.conduit.plist`
 - **Linux**: `~/.config/systemd/user/conduit.service`
 
 ### `conduit service start`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -256,7 +256,7 @@ conduit-daemon --foreground --log-level=debug
 
 | Platform | Service File |
 |----------|-------------|
-| macOS | `~/Library/LaunchAgents/com.simpleflo.conduit.plist` |
+| macOS | `~/Library/LaunchAgents/dev.simpleflo.conduit.plist` |
 | Linux | `~/.config/systemd/user/conduit.service` |
 
 ### Viewing Logs

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -1206,7 +1206,7 @@ func (i *Installer) setupLaunchdService(binaryPath string) InstallResult {
 	}
 
 	plistDir := filepath.Join(homeDir, "Library", "LaunchAgents")
-	plistPath := filepath.Join(plistDir, "com.simpleflo.conduit.plist")
+	plistPath := filepath.Join(plistDir, "dev.simpleflo.conduit.plist")
 	conduitHome := filepath.Join(homeDir, ".conduit")
 
 	// Create directory
@@ -1219,7 +1219,7 @@ func (i *Installer) setupLaunchdService(binaryPath string) InstallResult {
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.simpleflo.conduit</string>
+    <string>dev.simpleflo.conduit</string>
     <key>ProgramArguments</key>
     <array>
         <string>%s</string>
@@ -1252,7 +1252,7 @@ func (i *Installer) setupLaunchdService(binaryPath string) InstallResult {
 	}
 
 	// Start the service
-	_ = exec.Command("launchctl", "start", "com.simpleflo.conduit").Run()
+	_ = exec.Command("launchctl", "start", "dev.simpleflo.conduit").Run()
 
 	fmt.Println("✓ Daemon service installed (launchd)")
 	fmt.Println("  The daemon will start automatically on login.")
@@ -1322,7 +1322,7 @@ WantedBy=default.target
 func (i *Installer) StopDaemonService() error {
 	switch runtime.GOOS {
 	case "darwin":
-		return exec.Command("launchctl", "stop", "com.simpleflo.conduit").Run()
+		return exec.Command("launchctl", "stop", "dev.simpleflo.conduit").Run()
 	case "linux":
 		return exec.Command("systemctl", "--user", "stop", "conduit").Run()
 	default:
@@ -1336,7 +1336,7 @@ func (i *Installer) RemoveDaemonService() error {
 
 	switch runtime.GOOS {
 	case "darwin":
-		plistPath := filepath.Join(homeDir, "Library", "LaunchAgents", "com.simpleflo.conduit.plist")
+		plistPath := filepath.Join(homeDir, "Library", "LaunchAgents", "dev.simpleflo.conduit.plist")
 		_ = exec.Command("launchctl", "unload", plistPath).Run()
 		return os.Remove(plistPath)
 	case "linux":

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1550,13 +1550,13 @@ setup_service() {
 
 # Setup launchd service (macOS)
 setup_launchd_service() {
-    local PLIST_PATH="$HOME/Library/LaunchAgents/com.simpleflo.conduit.plist"
+    local PLIST_PATH="$HOME/Library/LaunchAgents/dev.simpleflo.conduit.plist"
 
     mkdir -p "$HOME/Library/LaunchAgents"
 
     # Stop any existing daemon completely
     info "Stopping any existing daemon..."
-    launchctl stop com.simpleflo.conduit 2>/dev/null || true
+    launchctl stop dev.simpleflo.conduit 2>/dev/null || true
     launchctl unload "$PLIST_PATH" 2>/dev/null || true
 
     # Kill any lingering daemon processes (in case started manually)
@@ -1578,7 +1578,7 @@ setup_launchd_service() {
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.simpleflo.conduit</string>
+    <string>dev.simpleflo.conduit</string>
     <key>ProgramArguments</key>
     <array>
         <string>${INSTALL_DIR}/conduit-daemon</string>
@@ -1615,7 +1615,7 @@ EOF
     # Load and start the service
     info "Loading and starting daemon service..."
     launchctl load "$PLIST_PATH"
-    launchctl start com.simpleflo.conduit
+    launchctl start dev.simpleflo.conduit
 
     success "Conduit daemon installed as launchd service"
     success "PATH configured in service (includes /opt/homebrew/bin for Homebrew tools)"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -153,9 +153,9 @@ stop_daemon() {
         # Try to stop via service
         case $OS in
             darwin)
-                if launchctl list | grep -q "com.simpleflo.conduit"; then
+                if launchctl list | grep -q "dev.simpleflo.conduit"; then
                     info "Stopping launchd service..."
-                    launchctl stop com.simpleflo.conduit 2>/dev/null || true
+                    launchctl stop dev.simpleflo.conduit 2>/dev/null || true
                     success "Daemon stopped"
                 fi
                 ;;
@@ -195,7 +195,7 @@ remove_service() {
 
     case $OS in
         darwin)
-            local PLIST_PATH="$HOME/Library/LaunchAgents/com.simpleflo.conduit.plist"
+            local PLIST_PATH="$HOME/Library/LaunchAgents/dev.simpleflo.conduit.plist"
             if [[ -f "$PLIST_PATH" ]]; then
                 if confirm "Remove launchd service?"; then
                     info "Unloading service..."


### PR DESCRIPTION
## Summary

- Updated app bundle identifier from `com.simpleflo.conduit` to `dev.simpleflo.conduit` to match the product domain `simpleflo.dev`
- Fixed desktop menu Help links to point to correct URLs:
  - Documentation: `https://conduit.simpleflo.dev`
  - Report Issue: `https://github.com/amlandas/Conduit-AI-Intelligence-Hub/issues`

## Changed Files (10 files)

### Desktop App
- `apps/conduit-desktop/electron-builder.yml` - App ID
- `apps/conduit-desktop/src/main/index.ts` - setAppUserModelId
- `apps/conduit-desktop/src/main/menu.ts` - Help menu URLs

### Go Code
- `internal/installer/installer.go` - launchd service identifier
- `cmd/conduit/main.go` - service commands

### Shell Scripts
- `scripts/install.sh` - launchd plist configuration
- `scripts/uninstall.sh` - service removal

### Documentation
- `docs/ADMIN_GUIDE.md` - Service file references
- `docs/CLI_COMMAND_INDEX.md` - Service file location
- `docs/USER_GUIDE.md` - Service file location

## Rationale

The product domain is `simpleflo.dev` with `conduit.simpleflo.dev` as the product subdomain. In reverse domain notation:
- ❌ `com.simpleflo.conduit` (incorrect - implies .com TLD)
- ✅ `dev.simpleflo.conduit` (correct - matches .dev TLD)

## Test plan

- [x] Go tests pass (`make test`)
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] Desktop app builds successfully (`npm run build`)
- [x] Verified no remaining `com.simpleflo.conduit` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)