### PR TITLE
docs: Add Desktop UI documentation and update V1 roadmap status

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,45 @@ conduit setup
 conduit service status
 ```
 
+## Desktop App (macOS)
+
+Conduit includes a native macOS desktop application for users who prefer a graphical interface.
+
+### Running the Desktop App
+
+```bash
+# From the repository root
+cd apps/conduit-desktop
+
+# Install dependencies
+npm install
+
+# Run in development mode
+npm run dev
+
+# Build for production
+npm run build
+
+# Package as DMG
+npm run package:mac:dmg
+```
+
+### Desktop App Features
+
+- **Dashboard**: Real-time status of daemon, Ollama, Qdrant, FalkorDB, and container runtime
+- **Knowledge Base**: Search, manage sources, view sync progress
+- **Connectors**: Start/stop instances, manage bindings
+- **Settings**: Theme, mode selection (Default/Advanced/Developer)
+- **Auto-Updates**: Automatic update checks from GitHub Releases
+
+### Mode System
+
+| Mode | Features |
+|------|----------|
+| **Default** | Full visibility, simple controls |
+| **Advanced** | RAG/KAG tuning sliders, container controls, permissions |
+| **Developer** | Config editor, log viewer, daemon controls, API toggle |
+
 ## Project Structure
 
 ```

--- a/docs/V0_OUTCOME.md
+++ b/docs/V0_OUTCOME.md
@@ -521,12 +521,20 @@ During user testing, several critical bugs were identified and resolved:
 
 | Feature | Status | Description |
 |---------|--------|-------------|
-| **Desktop App** | 🔵 Designed | Native macOS app with Electron + React + shadcn/ui |
-| **SSE Events** | 📋 Planned | Real-time daemon-UI sync via Server-Sent Events |
-| **Mode System** | 📋 Planned | Default/Advanced/Developer tier modes |
-| **Dependency Dashboard** | 📋 Planned | Status of Ollama, Qdrant, FalkorDB, container runtime |
+| **Desktop App** | ✅ Complete | Native macOS app with Electron + React + shadcn/ui |
+| **SSE Events** | ✅ Complete | Real-time daemon-UI sync via Server-Sent Events |
+| **Mode System** | ✅ Complete | Default/Advanced/Developer tier modes |
+| **Dependency Dashboard** | ✅ Complete | Status of Ollama, Qdrant, FalkorDB, container runtime |
+| **Auto-Updates** | ✅ Complete | electron-updater with GitHub Releases integration |
+| **DMG Packaging** | ✅ Complete | Signed DMG builds for distribution |
 
-**Design Document**: See `~/.claude/plans/zippy-riding-lemur.md` for full V1 UI design.
+**Implementation PRs**:
+- PR #11: Phase 1 & 2 - Electron foundation + Core views with SSE sync
+- PR #12: Phase 4 & 5 - Advanced/Developer modes + Performance optimization
+- PR #13: Phase 6 - Distribution with auto-updates
+- PR #14: Branding consistency (app ID: `dev.simpleflo.conduit`)
+
+**Desktop App Location**: `apps/conduit-desktop/`
 
 ### Recently Completed (Post-V0)
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect completion of the 6-phase Desktop UI implementation, as required by CLAUDE.md post-implementation guidelines.

## Changes

### V0_OUTCOME.md
- Updated V1 Roadmap section: Changed all Desktop UI features from "Planned/Designed" to "Complete"
- Added PRs #11-14 references for traceability
- Added new completed features: Auto-Updates, DMG Packaging

### PROJECT_LEARNINGS.md
- Added Phase 16: macOS Desktop Application
- Documents implementation overview, technology stack, architecture decisions
- Includes lessons learned from the development process

### README.md
- Added "Desktop App (macOS)" section with build and run instructions
- Documents Mode System (Default/Advanced/Developer)
- Lists key features of the desktop application

## Test plan

- [x] Documentation changes only - no code changes
- [x] All markdown renders correctly
- [x] Links and references are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)