### PR TITLE
feat(uninstall): add unified uninstallation system

### DIFF
--- a/apps/conduit-desktop/src/main/index.ts
+++ b/apps/conduit-desktop/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { setupIpcHandlers } from './ipc'
 import { setupSetupIpcHandlers } from './setup-ipc'
+import { setupUninstallIpcHandlers } from './uninstall-ipc'
 import { createApplicationMenu } from './menu'
 import { initAutoUpdater } from './updater'
 
@@ -54,6 +55,7 @@ app.whenReady().then(() => {
   createApplicationMenu()
   setupIpcHandlers()
   setupSetupIpcHandlers()
+  setupUninstallIpcHandlers()
   createWindow()
 
   // Initialize auto-updater after window is created

--- a/apps/conduit-desktop/src/main/uninstall-ipc.ts
+++ b/apps/conduit-desktop/src/main/uninstall-ipc.ts
@@ -1,0 +1,492 @@
+/**
+ * Uninstall IPC Handlers
+ *
+ * Provides IPC handlers for the Desktop app's uninstall functionality.
+ * Delegates to the Go CLI for actual uninstallation to ensure consistency.
+ */
+
+import { ipcMain, shell } from 'electron'
+import { execFileSync } from 'child_process'
+import * as os from 'os'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as http from 'http'
+
+export interface UninstallInfo {
+  hasDaemonService: boolean
+  daemonRunning: boolean
+  servicePath: string | null
+
+  hasBinaries: boolean
+  conduitPath: string | null
+  daemonPath: string | null
+  conduitVersion: string | null
+
+  hasDataDir: boolean
+  dataDirPath: string | null
+  dataDirSize: string | null
+  dataDirSizeRaw: number
+
+  containerRuntime: string | null
+  hasQdrantContainer: boolean
+  qdrantContainerRunning: boolean
+  qdrantVectorCount: number
+  hasFalkorDBContainer: boolean
+  falkordbContainerRunning: boolean
+
+  hasOllama: boolean
+  ollamaRunning: boolean
+  ollamaModels: string[]
+  ollamaSize: string | null
+  ollamaSizeRaw: number
+
+  hasShellConfig: boolean
+  shellConfigFiles: string[]
+
+  hasSymlinks: boolean
+  symlinks: string[]
+}
+
+export interface UninstallOptions {
+  tier: 'keep-data' | 'all' | 'full'
+  removeOllama: boolean
+  force: boolean
+}
+
+export interface UninstallResult {
+  success: boolean
+  itemsRemoved: string[]
+  itemsFailed: string[]
+  errors: string[]
+}
+
+/**
+ * Sets up IPC handlers for uninstall functionality
+ */
+export function setupUninstallIpcHandlers(): void {
+  // Get uninstall info
+  ipcMain.handle('uninstall:get-info', async (): Promise<UninstallInfo> => {
+    return getUninstallInfo()
+  })
+
+  // Dry run - show what would be removed
+  ipcMain.handle(
+    'uninstall:dry-run',
+    async (_, options: UninstallOptions): Promise<string[]> => {
+      return dryRunUninstall(options)
+    }
+  )
+
+  // Execute uninstall
+  ipcMain.handle(
+    'uninstall:execute',
+    async (_, options: UninstallOptions): Promise<UninstallResult> => {
+      return executeUninstall(options)
+    }
+  )
+
+  // Open data directory in Finder/Explorer
+  ipcMain.handle('uninstall:open-data-dir', async (): Promise<void> => {
+    const homeDir = os.homedir()
+    const conduitHome = path.join(homeDir, '.conduit')
+    if (fs.existsSync(conduitHome)) {
+      await shell.openPath(conduitHome)
+    }
+  })
+}
+
+/**
+ * Gather information about what's installed
+ */
+function getUninstallInfo(): UninstallInfo {
+  const homeDir = os.homedir()
+  const info: UninstallInfo = {
+    hasDaemonService: false,
+    daemonRunning: false,
+    servicePath: null,
+
+    hasBinaries: false,
+    conduitPath: null,
+    daemonPath: null,
+    conduitVersion: null,
+
+    hasDataDir: false,
+    dataDirPath: null,
+    dataDirSize: null,
+    dataDirSizeRaw: 0,
+
+    containerRuntime: null,
+    hasQdrantContainer: false,
+    qdrantContainerRunning: false,
+    qdrantVectorCount: 0,
+    hasFalkorDBContainer: false,
+    falkordbContainerRunning: false,
+
+    hasOllama: false,
+    ollamaRunning: false,
+    ollamaModels: [],
+    ollamaSize: null,
+    ollamaSizeRaw: 0,
+
+    hasShellConfig: false,
+    shellConfigFiles: [],
+
+    hasSymlinks: false,
+    symlinks: []
+  }
+
+  // Check daemon service
+  if (process.platform === 'darwin') {
+    const plistPath = path.join(homeDir, 'Library', 'LaunchAgents', 'dev.simpleflo.conduit.plist')
+    if (fs.existsSync(plistPath)) {
+      info.hasDaemonService = true
+      info.servicePath = plistPath
+    }
+  } else if (process.platform === 'linux') {
+    const servicePath = path.join(homeDir, '.config', 'systemd', 'user', 'conduit.service')
+    if (fs.existsSync(servicePath)) {
+      info.hasDaemonService = true
+      info.servicePath = servicePath
+    }
+  }
+
+  // Check daemon running via HTTP
+  info.daemonRunning = checkDaemonRunningSync()
+
+  // Check binaries
+  const localBin = path.join(homeDir, '.local', 'bin')
+  const conduitPath = path.join(localBin, 'conduit')
+  const daemonPath = path.join(localBin, 'conduit-daemon')
+
+  if (fs.existsSync(conduitPath)) {
+    info.hasBinaries = true
+    info.conduitPath = conduitPath
+    try {
+      info.conduitVersion = execFileSync(conduitPath, ['--version'], { encoding: 'utf8' }).trim()
+    } catch {
+      // Ignore version errors
+    }
+  }
+  if (fs.existsSync(daemonPath)) {
+    info.hasBinaries = true
+    info.daemonPath = daemonPath
+  }
+
+  // Check data directory
+  const conduitHome = path.join(homeDir, '.conduit')
+  if (fs.existsSync(conduitHome) && fs.statSync(conduitHome).isDirectory()) {
+    info.hasDataDir = true
+    info.dataDirPath = conduitHome
+    info.dataDirSizeRaw = getDirectorySize(conduitHome)
+    info.dataDirSize = formatSize(info.dataDirSizeRaw)
+  }
+
+  // Check container runtime and containers
+  info.containerRuntime = detectContainerRuntime()
+  if (info.containerRuntime) {
+    const qdrantInfo = checkContainer(info.containerRuntime, 'conduit-qdrant')
+    info.hasQdrantContainer = qdrantInfo.exists
+    info.qdrantContainerRunning = qdrantInfo.running
+
+    const falkorInfo = checkContainer(info.containerRuntime, 'conduit-falkordb')
+    info.hasFalkorDBContainer = falkorInfo.exists
+    info.falkordbContainerRunning = falkorInfo.running
+
+    // Get Qdrant vector count if running
+    if (info.qdrantContainerRunning) {
+      info.qdrantVectorCount = getQdrantVectorCount()
+    }
+  }
+
+  // Check Ollama
+  if (commandExists('ollama')) {
+    info.hasOllama = true
+    info.ollamaRunning = checkOllamaRunningSync()
+    info.ollamaModels = getOllamaModels()
+
+    const ollamaDir = path.join(homeDir, '.ollama')
+    if (fs.existsSync(ollamaDir)) {
+      info.ollamaSizeRaw = getDirectorySize(ollamaDir)
+      info.ollamaSize = formatSize(info.ollamaSizeRaw)
+    }
+  }
+
+  // Check shell configs
+  const shellConfigs = [
+    path.join(homeDir, '.zshrc'),
+    path.join(homeDir, '.bashrc'),
+    path.join(homeDir, '.bash_profile')
+  ]
+  const localBinPath = path.join(homeDir, '.local', 'bin')
+
+  for (const config of shellConfigs) {
+    if (fs.existsSync(config)) {
+      const content = fs.readFileSync(config, 'utf8')
+      if (content.includes(localBinPath) || content.includes('# Conduit')) {
+        info.hasShellConfig = true
+        info.shellConfigFiles.push(config)
+      }
+    }
+  }
+
+  // Check symlinks
+  const possibleSymlinks = ['/usr/local/bin/conduit', '/usr/local/bin/conduit-daemon']
+  for (const link of possibleSymlinks) {
+    try {
+      const target = fs.readlinkSync(link)
+      if (target.includes('.local/bin')) {
+        info.hasSymlinks = true
+        info.symlinks.push(link)
+      }
+    } catch {
+      // Not a symlink or doesn't exist
+    }
+  }
+
+  return info
+}
+
+/**
+ * Dry run - returns what would be removed
+ */
+function dryRunUninstall(options: UninstallOptions): string[] {
+  const conduitPath = findConduitCLI()
+  if (!conduitPath) {
+    return ['Error: Conduit CLI not found. Cannot perform dry run.']
+  }
+
+  try {
+    const flags = buildCLIFlags(options, true)
+    const result = execFileSync(conduitPath, ['uninstall', ...flags], {
+      encoding: 'utf8',
+      timeout: 30000
+    })
+    return result
+      .split('\n')
+      .filter((line) => line.includes('[DRY RUN]'))
+      .map((line) => line.replace('[DRY RUN]', '').trim())
+  } catch (error) {
+    return [`Error: ${error instanceof Error ? error.message : String(error)}`]
+  }
+}
+
+/**
+ * Execute uninstall via CLI
+ */
+function executeUninstall(options: UninstallOptions): UninstallResult {
+  const result: UninstallResult = {
+    success: true,
+    itemsRemoved: [],
+    itemsFailed: [],
+    errors: []
+  }
+
+  const conduitPath = findConduitCLI()
+  if (!conduitPath) {
+    result.success = false
+    result.errors.push('Conduit CLI not found. Please uninstall manually.')
+    return result
+  }
+
+  try {
+    const flags = buildCLIFlags(options, false)
+    const output = execFileSync(conduitPath, ['uninstall', ...flags, '--json'], {
+      encoding: 'utf8',
+      timeout: 120000 // 2 minutes for uninstall
+    })
+
+    // Parse JSON result from CLI
+    const cliResult = JSON.parse(output) as {
+      success: boolean
+      itemsRemoved: string[]
+      itemsFailed: string[]
+      errors: string[]
+    }
+
+    result.success = cliResult.success
+    result.itemsRemoved = cliResult.itemsRemoved || []
+    result.itemsFailed = cliResult.itemsFailed || []
+    result.errors = cliResult.errors || []
+  } catch (error) {
+    result.success = false
+    result.errors.push(`Uninstall failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  return result
+}
+
+// Helper functions
+
+function findConduitCLI(): string | null {
+  const homeDir = os.homedir()
+
+  // Check PATH first using 'which' command
+  try {
+    const whichCmd = process.platform === 'win32' ? 'where.exe' : 'which'
+    const result = execFileSync(whichCmd, ['conduit'], { encoding: 'utf8' }).trim()
+    if (result) return result.split('\n')[0]
+  } catch {
+    // Not in PATH
+  }
+
+  // Check ~/.local/bin
+  const localBinPath = path.join(homeDir, '.local', 'bin', 'conduit')
+  if (fs.existsSync(localBinPath)) {
+    return localBinPath
+  }
+
+  return null
+}
+
+function buildCLIFlags(options: UninstallOptions, dryRun: boolean): string[] {
+  const flags: string[] = []
+
+  // Tier flags
+  switch (options.tier) {
+    case 'keep-data':
+      flags.push('--keep-data')
+      break
+    case 'all':
+      flags.push('--all')
+      break
+    case 'full':
+      flags.push('--full')
+      break
+  }
+
+  if (options.removeOllama) {
+    flags.push('--remove-ollama')
+  }
+
+  if (options.force) {
+    flags.push('--force')
+  }
+
+  if (dryRun) {
+    flags.push('--dry-run')
+  }
+
+  return flags
+}
+
+function checkDaemonRunningSync(): boolean {
+  // Simple sync check using curl
+  try {
+    execFileSync('curl', ['-s', '--connect-timeout', '2', 'http://localhost:9090/health'], {
+      encoding: 'utf8',
+      timeout: 3000
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function detectContainerRuntime(): string | null {
+  if (commandExists('podman')) return 'podman'
+  if (commandExists('docker')) return 'docker'
+  return null
+}
+
+function commandExists(cmd: string): boolean {
+  try {
+    const whichCmd = process.platform === 'win32' ? 'where.exe' : 'which'
+    execFileSync(whichCmd, [cmd], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function checkContainer(runtime: string, name: string): { exists: boolean; running: boolean } {
+  try {
+    // Check if container exists
+    const allContainers = execFileSync(runtime, ['ps', '-a', '--format', '{{.Names}}'], {
+      encoding: 'utf8'
+    })
+    const exists = allContainers.split('\n').some((n) => n.trim() === name)
+
+    if (!exists) {
+      return { exists: false, running: false }
+    }
+
+    // Check if running
+    const runningContainers = execFileSync(runtime, ['ps', '--format', '{{.Names}}'], {
+      encoding: 'utf8'
+    })
+    const running = runningContainers.split('\n').some((n) => n.trim() === name)
+
+    return { exists, running }
+  } catch {
+    return { exists: false, running: false }
+  }
+}
+
+function getQdrantVectorCount(): number {
+  try {
+    const response = execFileSync('curl', ['-s', 'http://localhost:6333/collections/conduit_kb'], {
+      encoding: 'utf8',
+      timeout: 5000
+    })
+    const match = response.match(/"points_count":\s*(\d+)/)
+    return match ? parseInt(match[1], 10) : 0
+  } catch {
+    return 0
+  }
+}
+
+function checkOllamaRunningSync(): boolean {
+  try {
+    execFileSync('curl', ['-s', '--connect-timeout', '2', 'http://localhost:11434/api/tags'], {
+      timeout: 3000
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function getOllamaModels(): string[] {
+  try {
+    const response = execFileSync('curl', ['-s', 'http://localhost:11434/api/tags'], {
+      encoding: 'utf8',
+      timeout: 5000
+    })
+    const data = JSON.parse(response) as { models?: Array<{ name: string }> }
+    return data.models?.map((m) => m.name) || []
+  } catch {
+    return []
+  }
+}
+
+function getDirectorySize(dirPath: string): number {
+  let size = 0
+  try {
+    const files = fs.readdirSync(dirPath)
+    for (const file of files) {
+      const filePath = path.join(dirPath, file)
+      const stats = fs.statSync(filePath)
+      if (stats.isDirectory()) {
+        size += getDirectorySize(filePath)
+      } else {
+        size += stats.size
+      }
+    }
+  } catch {
+    // Ignore permission errors
+  }
+  return size
+}
+
+function formatSize(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let unitIndex = 0
+  let size = bytes
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex++
+  }
+
+  return `${size.toFixed(1)} ${units[unitIndex]}`
+}

--- a/apps/conduit-desktop/src/preload/index.ts
+++ b/apps/conduit-desktop/src/preload/index.ts
@@ -41,6 +41,54 @@ export interface ServiceStatus {
   error?: string
 }
 
+export interface UninstallInfo {
+  hasDaemonService: boolean
+  daemonRunning: boolean
+  servicePath: string | null
+
+  hasBinaries: boolean
+  conduitPath: string | null
+  daemonPath: string | null
+  conduitVersion: string | null
+
+  hasDataDir: boolean
+  dataDirPath: string | null
+  dataDirSize: string | null
+  dataDirSizeRaw: number
+
+  containerRuntime: string | null
+  hasQdrantContainer: boolean
+  qdrantContainerRunning: boolean
+  qdrantVectorCount: number
+  hasFalkorDBContainer: boolean
+  falkordbContainerRunning: boolean
+
+  hasOllama: boolean
+  ollamaRunning: boolean
+  ollamaModels: string[]
+  ollamaSize: string | null
+  ollamaSizeRaw: number
+
+  hasShellConfig: boolean
+  shellConfigFiles: string[]
+
+  hasSymlinks: boolean
+  symlinks: string[]
+}
+
+export interface UninstallOptions {
+  tier: 'keep-data' | 'all' | 'full'
+  removeOllama: boolean
+  force: boolean
+}
+
+export interface UninstallResult {
+  success: boolean
+  itemsRemoved: string[]
+  itemsFailed: string[]
+  errors: string[]
+}
+
 export interface ConduitAPI {
   // App info
   getVersion: () => Promise<string>
@@ -103,6 +151,12 @@ export interface ConduitAPI {
   // Shell operations
   openExternal: (url: string) => Promise<void>
   openTerminal: () => Promise<void>
+
+  // Uninstall
+  getUninstallInfo: () => Promise<UninstallInfo>
+  uninstallDryRun: (options: UninstallOptions) => Promise<string[]>
+  executeUninstall: (options: UninstallOptions) => Promise<UninstallResult>
+  openDataDir: () => Promise<void>
 
   // Event listeners
   onEvent: (callback: (event: unknown) => void) => () => void
@@ -184,6 +238,12 @@ const conduitAPI: ConduitAPI = {
   // Shell operations
   openExternal: (url) => ipcRenderer.invoke('shell:open-external', url),
   openTerminal: () => ipcRenderer.invoke('shell:open-terminal'),
+
+  // Uninstall
+  getUninstallInfo: () => ipcRenderer.invoke('uninstall:get-info'),
+  uninstallDryRun: (options) => ipcRenderer.invoke('uninstall:dry-run', options),
+  executeUninstall: (options) => ipcRenderer.invoke('uninstall:execute', options),
+  openDataDir: () => ipcRenderer.invoke('uninstall:open-data-dir'),
 
   // Event listeners with cleanup
   onEvent: (callback) => {

--- a/apps/conduit-desktop/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/conduit-desktop/src/renderer/components/settings/SettingsView.tsx
@@ -4,6 +4,7 @@ import { useSettingsStore, AppMode } from '@/stores'
 import { RAGTuningPanel, RAGSettings } from '../kb/RAGTuningPanel'
 import { DaemonControls } from './DaemonControls'
 import { LogViewer } from './LogViewer'
+import { UninstallPanel } from './UninstallPanel'
 import {
   Monitor,
   Moon,
@@ -21,7 +22,8 @@ import {
   FileCode,
   Server,
   ScrollText,
-  Loader2
+  Loader2,
+  Trash2
 } from 'lucide-react'
 
 // Lazy load Monaco editor for better initial load performance
@@ -425,6 +427,15 @@ export function SettingsView(): JSX.Element {
           <LogViewer />
         </section>
       )}
+
+      {/* Uninstall */}
+      <section>
+        <h2 className="text-lg font-medium mb-4 flex items-center gap-2">
+          <Trash2 className="w-5 h-5 text-macos-red" />
+          Uninstall
+        </h2>
+        <UninstallPanel />
+      </section>
 
       {/* About */}
       <section>

--- a/apps/conduit-desktop/src/renderer/components/settings/UninstallPanel.tsx
+++ b/apps/conduit-desktop/src/renderer/components/settings/UninstallPanel.tsx
@@ -1,0 +1,683 @@
+/**
+ * UninstallPanel - GUI component for uninstalling Conduit
+ *
+ * Provides three uninstall tiers:
+ * 1. Keep Data - Remove binaries, services, but keep ~/.conduit/
+ * 2. All - Remove everything except system tools (Docker/Podman)
+ * 3. Full - Same as All, plus optional Ollama removal
+ */
+
+import { useState, useEffect } from 'react'
+import { cn } from '@/lib/utils'
+import { Modal, ModalFooter } from '../ui/Modal'
+import {
+  AlertTriangle,
+  Database,
+  Server,
+  HardDrive,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  ExternalLink,
+  Box,
+  Cpu,
+  FileCode
+} from 'lucide-react'
+
+interface UninstallInfo {
+  hasDaemonService: boolean
+  daemonRunning: boolean
+  servicePath: string | null
+
+  hasBinaries: boolean
+  conduitPath: string | null
+  daemonPath: string | null
+  conduitVersion: string | null
+
+  hasDataDir: boolean
+  dataDirPath: string | null
+  dataDirSize: string | null
+  dataDirSizeRaw: number
+
+  containerRuntime: string | null
+  hasQdrantContainer: boolean
+  qdrantContainerRunning: boolean
+  qdrantVectorCount: number
+  hasFalkorDBContainer: boolean
+  falkordbContainerRunning: boolean
+
+  hasOllama: boolean
+  ollamaRunning: boolean
+  ollamaModels: string[]
+  ollamaSize: string | null
+  ollamaSizeRaw: number
+
+  hasShellConfig: boolean
+  shellConfigFiles: string[]
+
+  hasSymlinks: boolean
+  symlinks: string[]
+}
+
+interface UninstallOptions {
+  tier: 'keep-data' | 'all' | 'full'
+  removeOllama: boolean
+  force: boolean
+}
+
+interface UninstallResult {
+  success: boolean
+  itemsRemoved: string[]
+  itemsFailed: string[]
+  errors: string[]
+}
+
+type UninstallTier = 'keep-data' | 'all' | 'full'
+
+interface TierOptionProps {
+  tier: UninstallTier
+  currentTier: UninstallTier
+  title: string
+  description: string
+  details: string[]
+  icon: typeof Server
+  danger?: boolean
+  onSelect: (tier: UninstallTier) => void
+}
+
+function TierOption({
+  tier,
+  currentTier,
+  title,
+  description,
+  details,
+  icon: Icon,
+  danger,
+  onSelect
+}: TierOptionProps): JSX.Element {
+  const isActive = tier === currentTier
+
+  return (
+    <button
+      onClick={() => onSelect(tier)}
+      className={cn(
+        'w-full text-left p-4 rounded-lg border-2 transition-colors',
+        isActive
+          ? danger
+            ? 'border-macos-red bg-macos-red/5'
+            : 'border-macos-blue bg-macos-blue/5'
+          : 'border-macos-separator dark:border-macos-separator-dark hover:border-macos-blue/50'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            'p-2 rounded-lg',
+            isActive
+              ? danger
+                ? 'bg-macos-red text-white'
+                : 'bg-macos-blue text-white'
+              : 'bg-macos-bg-secondary dark:bg-macos-bg-dark-tertiary'
+          )}
+        >
+          <Icon className="w-5 h-5" />
+        </div>
+        <div className="flex-1">
+          <h3 className="font-medium">{title}</h3>
+          <p className="mt-0.5 text-sm text-macos-text-secondary dark:text-macos-text-dark-secondary">
+            {description}
+          </p>
+          <ul className="mt-2 text-xs text-macos-text-tertiary dark:text-macos-text-dark-tertiary space-y-0.5">
+            {details.map((detail, i) => (
+              <li key={i} className="flex items-center gap-1">
+                <span className={cn(detail.startsWith('+') ? 'text-macos-red' : '')}>
+                  {detail}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {isActive && (
+          <div className={danger ? 'text-macos-red' : 'text-macos-blue'}>
+            <CheckCircle2 className="w-5 h-5" />
+          </div>
+        )}
+      </div>
+    </button>
+  )
+}
+
+interface ConfirmationModalProps {
+  open: boolean
+  onClose: () => void
+  onConfirm: () => void
+  info: UninstallInfo | null
+  tier: UninstallTier
+  removeOllama: boolean
+  isLoading: boolean
+}
+
+function ConfirmationModal({
+  open,
+  onClose,
+  onConfirm,
+  info,
+  tier,
+  removeOllama,
+  isLoading
+}: ConfirmationModalProps): JSX.Element | null {
+  const [confirmText, setConfirmText] = useState('')
+  const isConfirmed = confirmText === 'UNINSTALL'
+
+  useEffect(() => {
+    if (!open) setConfirmText('')
+  }, [open])
+
+  const needsConfirmation = tier !== 'keep-data'
+
+  return (
+    <Modal open={open} onClose={onClose} title="Confirm Uninstallation" className="w-[520px]">
+      <div className="p-5 space-y-4">
+        <div className="flex items-start gap-3 p-4 bg-macos-orange/10 dark:bg-macos-orange/20 rounded-lg">
+          <AlertTriangle className="w-6 h-6 text-macos-orange shrink-0 mt-0.5" />
+          <div>
+            <h3 className="font-medium text-macos-orange">Warning</h3>
+            <p className="text-sm text-macos-text-secondary dark:text-macos-text-dark-secondary mt-1">
+              {tier === 'keep-data'
+                ? 'This will remove Conduit binaries and services. Your data will be preserved.'
+                : 'This will permanently delete your data. This action cannot be undone.'}
+            </p>
+          </div>
+        </div>
+
+        {info && tier !== 'keep-data' && (
+          <div className="space-y-2">
+            <h4 className="text-sm font-medium">What will be removed:</h4>
+            <ul className="text-sm text-macos-text-secondary space-y-1.5">
+              {info.hasDataDir && (
+                <li className="flex items-center gap-2">
+                  <Database className="w-4 h-4 text-macos-red" />
+                  <span>Data directory ({info.dataDirSize})</span>
+                </li>
+              )}
+              {info.hasQdrantContainer && (
+                <li className="flex items-center gap-2">
+                  <Box className="w-4 h-4 text-macos-red" />
+                  <span>Qdrant container ({info.qdrantVectorCount.toLocaleString()} vectors)</span>
+                </li>
+              )}
+              {info.hasFalkorDBContainer && (
+                <li className="flex items-center gap-2">
+                  <Box className="w-4 h-4 text-macos-red" />
+                  <span>FalkorDB container</span>
+                </li>
+              )}
+              {removeOllama && info.hasOllama && (
+                <li className="flex items-center gap-2">
+                  <Cpu className="w-4 h-4 text-macos-red" />
+                  <span>
+                    Ollama ({info.ollamaSize})
+                    {info.ollamaModels.length > 0 && (
+                      <span className="text-macos-text-tertiary">
+                        {' '}
+                        - {info.ollamaModels.slice(0, 3).join(', ')}
+                        {info.ollamaModels.length > 3 && ` +${info.ollamaModels.length - 3} more`}
+                      </span>
+                    )}
+                  </span>
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
+
+        {needsConfirmation && (
+          <div className="space-y-2">
+            <label className="text-sm font-medium">
+              Type <span className="font-mono text-macos-red">UNINSTALL</span> to confirm:
+            </label>
+            <input
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value.toUpperCase())}
+              placeholder="Type UNINSTALL"
+              className={cn(
+                'w-full px-3 py-2 rounded-lg border-2 transition-colors',
+                'bg-white dark:bg-macos-bg-dark-tertiary',
+                isConfirmed
+                  ? 'border-macos-green'
+                  : 'border-macos-separator dark:border-macos-separator-dark',
+                'focus:outline-none focus:border-macos-blue'
+              )}
+              disabled={isLoading}
+              autoFocus
+            />
+          </div>
+        )}
+      </div>
+
+      <ModalFooter>
+        <button
+          onClick={onClose}
+          disabled={isLoading}
+          className="px-4 py-2 rounded-lg text-sm font-medium hover:bg-macos-bg-secondary dark:hover:bg-macos-bg-dark-tertiary transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          disabled={isLoading || (needsConfirmation && !isConfirmed)}
+          className={cn(
+            'px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors',
+            'disabled:opacity-50 disabled:cursor-not-allowed',
+            isLoading ? 'bg-macos-text-tertiary' : 'bg-macos-red hover:bg-macos-red/90'
+          )}
+        >
+          {isLoading ? (
+            <span className="flex items-center gap-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Uninstalling...
+            </span>
+          ) : (
+            'Uninstall Conduit'
+          )}
+        </button>
+      </ModalFooter>
+    </Modal>
+  )
+}
+
+export function UninstallPanel(): JSX.Element {
+  const [info, setInfo] = useState<UninstallInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [tier, setTier] = useState<UninstallTier>('keep-data')
+  const [removeOllama, setRemoveOllama] = useState(false)
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [isUninstalling, setIsUninstalling] = useState(false)
+  const [result, setResult] = useState<UninstallResult | null>(null)
+
+  useEffect(() => {
+    loadInfo()
+  }, [])
+
+  const loadInfo = async (): Promise<void> => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await window.conduit.getUninstallInfo()
+      setInfo(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load uninstall info')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleUninstall = async (): Promise<void> => {
+    try {
+      setIsUninstalling(true)
+      const options: UninstallOptions = {
+        tier,
+        removeOllama: tier === 'full' && removeOllama,
+        force: true
+      }
+      const result = await window.conduit.executeUninstall(options)
+      setResult(result)
+      if (result.success) {
+        setShowConfirm(false)
+      }
+    } catch (err) {
+      setResult({
+        success: false,
+        itemsRemoved: [],
+        itemsFailed: [],
+        errors: [err instanceof Error ? err.message : 'Uninstall failed']
+      })
+    } finally {
+      setIsUninstalling(false)
+    }
+  }
+
+  const handleOpenDataDir = async (): Promise<void> => {
+    await window.conduit.openDataDir()
+  }
+
+  if (loading) {
+    return (
+      <div className="card p-8 flex flex-col items-center justify-center gap-3">
+        <Loader2 className="w-8 h-8 animate-spin text-macos-text-secondary" />
+        <p className="text-sm text-macos-text-secondary">Loading uninstall information...</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="card p-6">
+        <div className="flex items-start gap-3 text-macos-red">
+          <XCircle className="w-5 h-5 shrink-0 mt-0.5" />
+          <div>
+            <h3 className="font-medium">Failed to load uninstall information</h3>
+            <p className="text-sm text-macos-text-secondary mt-1">{error}</p>
+            <button
+              onClick={loadInfo}
+              className="mt-3 text-sm text-macos-blue hover:underline"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (result) {
+    return (
+      <div className="card p-6">
+        <div
+          className={cn(
+            'flex items-start gap-3',
+            result.success ? 'text-macos-green' : 'text-macos-red'
+          )}
+        >
+          {result.success ? (
+            <CheckCircle2 className="w-6 h-6 shrink-0 mt-0.5" />
+          ) : (
+            <XCircle className="w-6 h-6 shrink-0 mt-0.5" />
+          )}
+          <div className="flex-1">
+            <h3 className="font-medium">
+              {result.success ? 'Uninstallation Complete' : 'Uninstallation Failed'}
+            </h3>
+
+            {result.itemsRemoved.length > 0 && (
+              <div className="mt-3">
+                <h4 className="text-sm font-medium text-macos-text-primary dark:text-macos-text-dark-primary">
+                  Removed:
+                </h4>
+                <ul className="mt-1 text-sm text-macos-text-secondary space-y-0.5">
+                  {result.itemsRemoved.map((item, i) => (
+                    <li key={i} className="flex items-center gap-1">
+                      <CheckCircle2 className="w-3.5 h-3.5 text-macos-green" />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {result.itemsFailed.length > 0 && (
+              <div className="mt-3">
+                <h4 className="text-sm font-medium text-macos-red">Failed:</h4>
+                <ul className="mt-1 text-sm text-macos-text-secondary space-y-0.5">
+                  {result.itemsFailed.map((item, i) => (
+                    <li key={i} className="flex items-center gap-1">
+                      <XCircle className="w-3.5 h-3.5 text-macos-red" />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {result.errors.length > 0 && (
+              <div className="mt-3">
+                <h4 className="text-sm font-medium text-macos-red">Errors:</h4>
+                <ul className="mt-1 text-sm text-macos-text-secondary space-y-0.5">
+                  {result.errors.map((err, i) => (
+                    <li key={i}>{err}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {result.success && (
+              <p className="mt-4 text-sm text-macos-text-secondary">
+                To complete the uninstallation, drag Conduit Desktop to Trash.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Installation Status */}
+      {info && (
+        <div className="card p-4 space-y-4">
+          <h3 className="text-sm font-medium">Current Installation</h3>
+
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            {/* Binaries */}
+            <div className="flex items-center gap-2">
+              <div
+                className={cn(
+                  'w-2 h-2 rounded-full',
+                  info.hasBinaries ? 'bg-macos-green' : 'bg-macos-text-tertiary'
+                )}
+              />
+              <span className="text-macos-text-secondary">CLI Binaries</span>
+              {info.conduitVersion && (
+                <span className="text-xs text-macos-text-tertiary">{info.conduitVersion}</span>
+              )}
+            </div>
+
+            {/* Daemon */}
+            <div className="flex items-center gap-2">
+              <div
+                className={cn(
+                  'w-2 h-2 rounded-full',
+                  info.daemonRunning
+                    ? 'bg-macos-green'
+                    : info.hasDaemonService
+                      ? 'bg-macos-orange'
+                      : 'bg-macos-text-tertiary'
+                )}
+              />
+              <span className="text-macos-text-secondary">Daemon Service</span>
+              <span className="text-xs text-macos-text-tertiary">
+                {info.daemonRunning ? 'Running' : info.hasDaemonService ? 'Stopped' : 'Not installed'}
+              </span>
+            </div>
+
+            {/* Data Directory */}
+            <div className="flex items-center gap-2">
+              <div
+                className={cn(
+                  'w-2 h-2 rounded-full',
+                  info.hasDataDir ? 'bg-macos-blue' : 'bg-macos-text-tertiary'
+                )}
+              />
+              <span className="text-macos-text-secondary">Data Directory</span>
+              {info.dataDirSize && (
+                <span className="text-xs text-macos-text-tertiary">{info.dataDirSize}</span>
+              )}
+              {info.hasDataDir && (
+                <button
+                  onClick={handleOpenDataDir}
+                  className="ml-auto text-macos-blue hover:text-macos-blue/80"
+                  title="Open in Finder"
+                >
+                  <ExternalLink className="w-3.5 h-3.5" />
+                </button>
+              )}
+            </div>
+
+            {/* Qdrant */}
+            <div className="flex items-center gap-2">
+              <div
+                className={cn(
+                  'w-2 h-2 rounded-full',
+                  info.qdrantContainerRunning
+                    ? 'bg-macos-green'
+                    : info.hasQdrantContainer
+                      ? 'bg-macos-orange'
+                      : 'bg-macos-text-tertiary'
+                )}
+              />
+              <span className="text-macos-text-secondary">Qdrant</span>
+              {info.hasQdrantContainer && (
+                <span className="text-xs text-macos-text-tertiary">
+                  {info.qdrantVectorCount.toLocaleString()} vectors
+                </span>
+              )}
+            </div>
+
+            {/* FalkorDB */}
+            <div className="flex items-center gap-2">
+              <div
+                className={cn(
+                  'w-2 h-2 rounded-full',
+                  info.falkordbContainerRunning
+                    ? 'bg-macos-green'
+                    : info.hasFalkorDBContainer
+                      ? 'bg-macos-orange'
+                      : 'bg-macos-text-tertiary'
+                )}
+              />
+              <span className="text-macos-text-secondary">FalkorDB</span>
+              <span className="text-xs text-macos-text-tertiary">
+                {info.hasFalkorDBContainer
+                  ? info.falkordbContainerRunning
+                    ? 'Running'
+                    : 'Stopped'
+                  : 'Not installed'}
+              </span>
+            </div>
+
+            {/* Ollama */}
+            <div className="flex items-center gap-2">
+              <div
+                className={cn(
+                  'w-2 h-2 rounded-full',
+                  info.ollamaRunning
+                    ? 'bg-macos-green'
+                    : info.hasOllama
+                      ? 'bg-macos-orange'
+                      : 'bg-macos-text-tertiary'
+                )}
+              />
+              <span className="text-macos-text-secondary">Ollama</span>
+              {info.hasOllama && info.ollamaSize && (
+                <span className="text-xs text-macos-text-tertiary">
+                  {info.ollamaModels.length} models ({info.ollamaSize})
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Tier Selection */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium">Choose what to remove:</h3>
+
+        <TierOption
+          tier="keep-data"
+          currentTier={tier}
+          title="Uninstall Only"
+          description="Remove binaries and services, but keep your data for reinstall"
+          details={[
+            'Stops daemon service',
+            'Removes CLI binaries',
+            'Cleans shell configuration',
+            'Keeps ~/.conduit/ and containers'
+          ]}
+          icon={Server}
+          onSelect={setTier}
+        />
+
+        <TierOption
+          tier="all"
+          currentTier={tier}
+          title="Uninstall + Remove Data"
+          description="Remove everything including your knowledge base data"
+          details={[
+            'Everything above PLUS:',
+            info?.dataDirSize ? `+ Removes ~/.conduit/ (${info.dataDirSize})` : '+ Removes ~/.conduit/',
+            info?.hasQdrantContainer
+              ? `+ Stops and removes Qdrant (${info.qdrantVectorCount.toLocaleString()} vectors)`
+              : '+ Stops and removes Qdrant',
+            '+ Stops and removes FalkorDB'
+          ]}
+          icon={Database}
+          danger
+          onSelect={setTier}
+        />
+
+        <TierOption
+          tier="full"
+          currentTier={tier}
+          title="Full Cleanup"
+          description="Remove everything with optional dependency cleanup"
+          details={[
+            'Everything above PLUS optional:',
+            info?.hasOllama
+              ? `+ Ollama (${info.ollamaModels.length} models, ${info.ollamaSize})`
+              : '+ Ollama (if installed)',
+            'Docker/Podman are NEVER removed'
+          ]}
+          icon={HardDrive}
+          danger
+          onSelect={setTier}
+        />
+      </div>
+
+      {/* Ollama Checkbox (only for full tier) */}
+      {tier === 'full' && info?.hasOllama && (
+        <div className="card p-4">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={removeOllama}
+              onChange={(e) => setRemoveOllama(e.target.checked)}
+              className="w-4 h-4 rounded border-macos-separator accent-macos-red"
+            />
+            <div className="flex-1">
+              <span className="text-sm font-medium">Remove Ollama</span>
+              <p className="text-xs text-macos-text-secondary mt-0.5">
+                This will remove Ollama and all downloaded models ({info.ollamaSize})
+              </p>
+            </div>
+          </label>
+        </div>
+      )}
+
+      {/* Notice about Docker/Podman */}
+      <div className="flex items-start gap-2 text-xs text-macos-text-tertiary">
+        <FileCode className="w-4 h-4 shrink-0 mt-0.5" />
+        <p>
+          Docker and Podman are system tools and will never be removed. Only Conduit-specific
+          containers (conduit-qdrant, conduit-falkordb) may be removed.
+        </p>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex items-center justify-end gap-3 pt-2">
+        <button
+          onClick={() => setShowConfirm(true)}
+          className={cn(
+            'px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors',
+            'bg-macos-red hover:bg-macos-red/90'
+          )}
+        >
+          Uninstall Conduit
+        </button>
+      </div>
+
+      {/* Confirmation Modal */}
+      <ConfirmationModal
+        open={showConfirm}
+        onClose={() => setShowConfirm(false)}
+        onConfirm={handleUninstall}
+        info={info}
+        tier={tier}
+        removeOllama={removeOllama}
+        isLoading={isUninstalling}
+      />
+    </div>
+  )
+}

--- a/internal/installer/uninstall.go
+++ b/internal/installer/uninstall.go
@@ -1,0 +1,761 @@
+// Package installer handles automated installation and uninstallation of Conduit.
+package installer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// UninstallOptions configures what components to remove during uninstallation.
+type UninstallOptions struct {
+	// Core removal
+	RemoveDaemonService bool // Stop daemon, remove launchd/systemd service
+	RemoveBinaries      bool // Remove ~/.local/bin/conduit and conduit-daemon
+	RemoveShellConfig   bool // Clean PATH from .zshrc, .bashrc
+	RemoveSymlinks      bool // Remove /usr/local/bin symlinks
+
+	// Data removal
+	RemoveDataDir    bool // Remove ~/.conduit/ entirely
+	RemoveConfigOnly bool // Remove only ~/.conduit/conduit.yaml (keep data)
+
+	// Container removal (selective)
+	RemoveQdrantContainer   bool // Stop and rm conduit-qdrant container
+	RemoveFalkorDBContainer bool // Stop and rm conduit-falkordb container
+
+	// Dependency removal
+	RemoveOllama bool // Remove Ollama binary and ~/.ollama models
+
+	// Safety flags
+	Force  bool // Skip confirmations
+	DryRun bool // Show what would be removed without doing it
+	JSON   bool // Output JSON for programmatic consumption
+}
+
+// UninstallInfo provides information about what's installed for UI display.
+type UninstallInfo struct {
+	// Daemon
+	HasDaemonService bool   `json:"hasDaemonService"`
+	DaemonRunning    bool   `json:"daemonRunning"`
+	DaemonPID        int    `json:"daemonPid,omitempty"`
+	ServicePath      string `json:"servicePath,omitempty"`
+
+	// Binaries
+	HasBinaries    bool   `json:"hasBinaries"`
+	ConduitPath    string `json:"conduitPath,omitempty"`
+	DaemonPath     string `json:"daemonPath,omitempty"`
+	ConduitVersion string `json:"conduitVersion,omitempty"`
+
+	// Data
+	HasDataDir     bool   `json:"hasDataDir"`
+	DataDirPath    string `json:"dataDirPath,omitempty"`
+	DataDirSize    string `json:"dataDirSize,omitempty"`
+	DataDirSizeRaw int64  `json:"dataDirSizeRaw,omitempty"`
+	HasConfig      bool   `json:"hasConfig"`
+	HasSQLite      bool   `json:"hasSqlite"`
+	DocumentCount  int    `json:"documentCount,omitempty"`
+	SourceCount    int    `json:"sourceCount,omitempty"`
+
+	// Containers
+	ContainerRuntime        string `json:"containerRuntime,omitempty"` // "docker", "podman", or ""
+	HasQdrantContainer      bool   `json:"hasQdrantContainer"`
+	QdrantContainerRunning  bool   `json:"qdrantContainerRunning"`
+	QdrantVectorCount       int64  `json:"qdrantVectorCount,omitempty"`
+	HasFalkorDBContainer    bool   `json:"hasFalkorDBContainer"`
+	FalkorDBContainerRunning bool  `json:"falkordbContainerRunning"`
+	FalkorDBEntityCount     int64  `json:"falkordbEntityCount,omitempty"`
+
+	// Ollama
+	HasOllama      bool     `json:"hasOllama"`
+	OllamaRunning  bool     `json:"ollamaRunning"`
+	OllamaModels   []string `json:"ollamaModels,omitempty"`
+	OllamaSize     string   `json:"ollamaSize,omitempty"`
+	OllamaSizeRaw  int64    `json:"ollamaSizeRaw,omitempty"`
+
+	// Shell config
+	HasShellConfig   bool     `json:"hasShellConfig"`
+	ShellConfigFiles []string `json:"shellConfigFiles,omitempty"`
+
+	// Symlinks
+	HasSymlinks bool     `json:"hasSymlinks"`
+	Symlinks    []string `json:"symlinks,omitempty"`
+}
+
+// UninstallResult tracks what was actually removed.
+type UninstallResult struct {
+	Success      bool     `json:"success"`
+	ItemsRemoved []string `json:"itemsRemoved"`
+	ItemsFailed  []string `json:"itemsFailed"`
+	Errors       []string `json:"errors"`
+}
+
+// NewUninstallOptionsKeepData returns options for Tier 1: Uninstall only (keep data).
+func NewUninstallOptionsKeepData() UninstallOptions {
+	return UninstallOptions{
+		RemoveDaemonService: true,
+		RemoveBinaries:      true,
+		RemoveShellConfig:   true,
+		RemoveSymlinks:      true,
+		RemoveDataDir:       false,
+		RemoveQdrantContainer:   false,
+		RemoveFalkorDBContainer: false,
+		RemoveOllama:        false,
+	}
+}
+
+// NewUninstallOptionsAll returns options for Tier 2: Uninstall with data.
+func NewUninstallOptionsAll() UninstallOptions {
+	return UninstallOptions{
+		RemoveDaemonService:     true,
+		RemoveBinaries:          true,
+		RemoveShellConfig:       true,
+		RemoveSymlinks:          true,
+		RemoveDataDir:           true,
+		RemoveQdrantContainer:   true,
+		RemoveFalkorDBContainer: true,
+		RemoveOllama:            false,
+	}
+}
+
+// NewUninstallOptionsFull returns options for Tier 3: Full cleanup.
+func NewUninstallOptionsFull() UninstallOptions {
+	opts := NewUninstallOptionsAll()
+	opts.RemoveOllama = true
+	return opts
+}
+
+// GetUninstallInfo gathers information about what's installed for UI display.
+func (i *Installer) GetUninstallInfo(ctx context.Context) (*UninstallInfo, error) {
+	info := &UninstallInfo{}
+	homeDir, _ := os.UserHomeDir()
+
+	// Check daemon service
+	info.HasDaemonService, info.ServicePath = i.checkDaemonServiceExists(homeDir)
+	info.DaemonRunning = i.checkDaemonRunning()
+
+	// Check binaries
+	localBin := filepath.Join(homeDir, ".local", "bin")
+	conduitPath := filepath.Join(localBin, "conduit")
+	daemonPath := filepath.Join(localBin, "conduit-daemon")
+
+	if _, err := os.Stat(conduitPath); err == nil {
+		info.HasBinaries = true
+		info.ConduitPath = conduitPath
+		// Get version
+		if out, err := exec.Command(conduitPath, "--version").Output(); err == nil {
+			info.ConduitVersion = strings.TrimSpace(string(out))
+		}
+	}
+	if _, err := os.Stat(daemonPath); err == nil {
+		info.HasBinaries = true
+		info.DaemonPath = daemonPath
+	}
+
+	// Check data directory
+	conduitHome := filepath.Join(homeDir, ".conduit")
+	if stat, err := os.Stat(conduitHome); err == nil && stat.IsDir() {
+		info.HasDataDir = true
+		info.DataDirPath = conduitHome
+		info.DataDirSizeRaw = i.getDirSize(conduitHome)
+		info.DataDirSize = formatSize(info.DataDirSizeRaw)
+
+		// Check for config
+		if _, err := os.Stat(filepath.Join(conduitHome, "conduit.yaml")); err == nil {
+			info.HasConfig = true
+		}
+
+		// Check for SQLite
+		if _, err := os.Stat(filepath.Join(conduitHome, "conduit.db")); err == nil {
+			info.HasSQLite = true
+			// Could query counts but keep it simple for now
+		}
+	}
+
+	// Check container runtime and containers
+	info.ContainerRuntime = i.detectContainerRuntime()
+	if info.ContainerRuntime != "" {
+		info.HasQdrantContainer, info.QdrantContainerRunning = i.checkContainer(info.ContainerRuntime, "conduit-qdrant")
+		info.HasFalkorDBContainer, info.FalkorDBContainerRunning = i.checkContainer(info.ContainerRuntime, "conduit-falkordb")
+
+		// Get Qdrant vector count if running
+		if info.QdrantContainerRunning {
+			info.QdrantVectorCount = i.getQdrantVectorCount()
+		}
+	}
+
+	// Check Ollama
+	if i.commandExists("ollama") {
+		info.HasOllama = true
+		info.OllamaRunning = i.checkOllamaRunning()
+		info.OllamaModels = i.getOllamaModels()
+
+		// Get ~/.ollama size
+		ollamaDir := filepath.Join(homeDir, ".ollama")
+		if stat, err := os.Stat(ollamaDir); err == nil && stat.IsDir() {
+			info.OllamaSizeRaw = i.getDirSize(ollamaDir)
+			info.OllamaSize = formatSize(info.OllamaSizeRaw)
+		}
+	}
+
+	// Check shell config
+	info.ShellConfigFiles = i.findShellConfigsWithConduit(homeDir)
+	info.HasShellConfig = len(info.ShellConfigFiles) > 0
+
+	// Check symlinks
+	info.Symlinks = i.findConduitSymlinks()
+	info.HasSymlinks = len(info.Symlinks) > 0
+
+	return info, nil
+}
+
+// UninstallWithOptions performs uninstallation based on provided options.
+func (i *Installer) UninstallWithOptions(ctx context.Context, opts UninstallOptions) (*UninstallResult, error) {
+	result := &UninstallResult{Success: true}
+	homeDir, _ := os.UserHomeDir()
+
+	if opts.DryRun {
+		return i.dryRunUninstall(ctx, opts)
+	}
+
+	// 1. Stop and remove daemon service
+	if opts.RemoveDaemonService {
+		if err := i.StopDaemonService(); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Failed to stop daemon: %v", err))
+		} else {
+			result.ItemsRemoved = append(result.ItemsRemoved, "Daemon service stopped")
+		}
+
+		if err := i.RemoveDaemonService(); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Failed to remove daemon service: %v", err))
+			result.ItemsFailed = append(result.ItemsFailed, "Daemon service")
+		} else {
+			result.ItemsRemoved = append(result.ItemsRemoved, "Daemon service removed")
+		}
+	}
+
+	// 2. Remove containers before data (they may write to data dir)
+	containerRuntime := i.detectContainerRuntime()
+	if opts.RemoveQdrantContainer && containerRuntime != "" {
+		if err := i.removeContainer(containerRuntime, "conduit-qdrant"); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Failed to remove Qdrant container: %v", err))
+			result.ItemsFailed = append(result.ItemsFailed, "Qdrant container")
+		} else {
+			result.ItemsRemoved = append(result.ItemsRemoved, "Qdrant container removed")
+		}
+	}
+
+	if opts.RemoveFalkorDBContainer && containerRuntime != "" {
+		if err := i.removeContainer(containerRuntime, "conduit-falkordb"); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Failed to remove FalkorDB container: %v", err))
+			result.ItemsFailed = append(result.ItemsFailed, "FalkorDB container")
+		} else {
+			result.ItemsRemoved = append(result.ItemsRemoved, "FalkorDB container removed")
+		}
+	}
+
+	// 3. Remove data directory
+	if opts.RemoveDataDir {
+		conduitHome := filepath.Join(homeDir, ".conduit")
+		if err := os.RemoveAll(conduitHome); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Failed to remove data dir: %v", err))
+			result.ItemsFailed = append(result.ItemsFailed, conduitHome)
+		} else {
+			result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("Data directory: %s", conduitHome))
+		}
+	} else if opts.RemoveConfigOnly {
+		configPath := filepath.Join(homeDir, ".conduit", "conduit.yaml")
+		if err := os.Remove(configPath); err != nil && !os.IsNotExist(err) {
+			result.Errors = append(result.Errors, fmt.Sprintf("Failed to remove config: %v", err))
+		} else {
+			result.ItemsRemoved = append(result.ItemsRemoved, "Config file removed")
+		}
+	}
+
+	// 4. Remove binaries
+	if opts.RemoveBinaries {
+		localBin := filepath.Join(homeDir, ".local", "bin")
+		binaries := []string{
+			filepath.Join(localBin, "conduit"),
+			filepath.Join(localBin, "conduit-daemon"),
+		}
+		for _, bin := range binaries {
+			if _, err := os.Stat(bin); err == nil {
+				if err := os.Remove(bin); err != nil {
+					result.Errors = append(result.Errors, fmt.Sprintf("Failed to remove %s: %v", bin, err))
+					result.ItemsFailed = append(result.ItemsFailed, bin)
+				} else {
+					result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("Binary: %s", bin))
+				}
+			}
+		}
+	}
+
+	// 5. Clean shell config
+	if opts.RemoveShellConfig {
+		removed := i.cleanupShellConfigSilent(homeDir)
+		for _, f := range removed {
+			result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("PATH removed from: %s", f))
+		}
+	}
+
+	// 6. Remove symlinks
+	if opts.RemoveSymlinks {
+		removed := i.cleanupSymlinksSilent()
+		for _, s := range removed {
+			result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("Symlink: %s", s))
+		}
+	}
+
+	// 7. Remove Ollama
+	if opts.RemoveOllama {
+		if err := i.removeOllama(homeDir); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Failed to remove Ollama: %v", err))
+			result.ItemsFailed = append(result.ItemsFailed, "Ollama")
+		} else {
+			result.ItemsRemoved = append(result.ItemsRemoved, "Ollama and models removed")
+		}
+	}
+
+	// Set success based on failures
+	result.Success = len(result.ItemsFailed) == 0
+
+	return result, nil
+}
+
+// dryRunUninstall returns what would be removed without actually removing anything.
+func (i *Installer) dryRunUninstall(ctx context.Context, opts UninstallOptions) (*UninstallResult, error) {
+	result := &UninstallResult{Success: true}
+	homeDir, _ := os.UserHomeDir()
+
+	if opts.RemoveDaemonService {
+		if exists, path := i.checkDaemonServiceExists(homeDir); exists {
+			result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("[DRY RUN] Would remove daemon service: %s", path))
+		}
+	}
+
+	containerRuntime := i.detectContainerRuntime()
+	if opts.RemoveQdrantContainer && containerRuntime != "" {
+		if exists, _ := i.checkContainer(containerRuntime, "conduit-qdrant"); exists {
+			result.ItemsRemoved = append(result.ItemsRemoved, "[DRY RUN] Would remove container: conduit-qdrant")
+		}
+	}
+
+	if opts.RemoveFalkorDBContainer && containerRuntime != "" {
+		if exists, _ := i.checkContainer(containerRuntime, "conduit-falkordb"); exists {
+			result.ItemsRemoved = append(result.ItemsRemoved, "[DRY RUN] Would remove container: conduit-falkordb")
+		}
+	}
+
+	if opts.RemoveDataDir {
+		conduitHome := filepath.Join(homeDir, ".conduit")
+		if stat, err := os.Stat(conduitHome); err == nil && stat.IsDir() {
+			size := formatSize(i.getDirSize(conduitHome))
+			result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("[DRY RUN] Would remove data dir: %s (%s)", conduitHome, size))
+		}
+	}
+
+	if opts.RemoveBinaries {
+		localBin := filepath.Join(homeDir, ".local", "bin")
+		for _, name := range []string{"conduit", "conduit-daemon"} {
+			path := filepath.Join(localBin, name)
+			if _, err := os.Stat(path); err == nil {
+				result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("[DRY RUN] Would remove binary: %s", path))
+			}
+		}
+	}
+
+	if opts.RemoveShellConfig {
+		files := i.findShellConfigsWithConduit(homeDir)
+		for _, f := range files {
+			result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("[DRY RUN] Would clean PATH from: %s", f))
+		}
+	}
+
+	if opts.RemoveSymlinks {
+		symlinks := i.findConduitSymlinks()
+		for _, s := range symlinks {
+			result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("[DRY RUN] Would remove symlink: %s", s))
+		}
+	}
+
+	if opts.RemoveOllama && i.commandExists("ollama") {
+		ollamaDir := filepath.Join(homeDir, ".ollama")
+		size := formatSize(i.getDirSize(ollamaDir))
+		result.ItemsRemoved = append(result.ItemsRemoved, fmt.Sprintf("[DRY RUN] Would remove Ollama and ~/.ollama (%s)", size))
+	}
+
+	return result, nil
+}
+
+// Helper methods
+
+func (i *Installer) checkDaemonServiceExists(homeDir string) (bool, string) {
+	switch runtime.GOOS {
+	case "darwin":
+		plistPath := filepath.Join(homeDir, "Library", "LaunchAgents", "dev.simpleflo.conduit.plist")
+		if _, err := os.Stat(plistPath); err == nil {
+			return true, plistPath
+		}
+	case "linux":
+		servicePath := filepath.Join(homeDir, ".config", "systemd", "user", "conduit.service")
+		if _, err := os.Stat(servicePath); err == nil {
+			return true, servicePath
+		}
+	}
+	return false, ""
+}
+
+func (i *Installer) checkDaemonRunning() bool {
+	// Try health endpoint
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://localhost:9090/health")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func (i *Installer) detectContainerRuntime() string {
+	if i.commandExists("podman") {
+		return "podman"
+	}
+	if i.commandExists("docker") {
+		return "docker"
+	}
+	return ""
+}
+
+func (i *Installer) checkContainer(runtime, name string) (exists bool, running bool) {
+	// Check if container exists
+	out, err := exec.Command(runtime, "ps", "-a", "--format", "{{.Names}}").Output()
+	if err != nil {
+		return false, false
+	}
+	if !strings.Contains(string(out), name) {
+		return false, false
+	}
+
+	// Check if running
+	out, err = exec.Command(runtime, "ps", "--format", "{{.Names}}").Output()
+	if err != nil {
+		return true, false
+	}
+	return true, strings.Contains(string(out), name)
+}
+
+func (i *Installer) removeContainer(runtime, name string) error {
+	// Stop container
+	_ = exec.Command(runtime, "stop", name).Run()
+
+	// Remove container
+	return exec.Command(runtime, "rm", name).Run()
+}
+
+func (i *Installer) checkOllamaRunning() bool {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://localhost:11434/api/tags")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func (i *Installer) getOllamaModels() []string {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("http://localhost:11434/api/tags")
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil
+	}
+
+	var models []string
+	for _, m := range result.Models {
+		models = append(models, m.Name)
+	}
+	return models
+}
+
+func (i *Installer) removeOllama(homeDir string) error {
+	// Stop Ollama service
+	switch runtime.GOOS {
+	case "darwin":
+		_ = exec.Command("pkill", "-f", "ollama serve").Run()
+	case "linux":
+		_ = exec.Command("systemctl", "--user", "stop", "ollama").Run()
+		_ = exec.Command("sudo", "systemctl", "stop", "ollama").Run()
+	}
+
+	// Wait for it to stop
+	time.Sleep(time.Second)
+
+	// Remove Ollama binary
+	binaryPaths := []string{
+		"/usr/local/bin/ollama",
+		"/usr/bin/ollama",
+	}
+	for _, path := range binaryPaths {
+		if _, err := os.Stat(path); err == nil {
+			// Need sudo to remove from these paths
+			if err := exec.Command("sudo", "rm", "-f", path).Run(); err != nil {
+				// Try without sudo (might work if user owns it)
+				_ = os.Remove(path)
+			}
+		}
+	}
+
+	// Remove ~/.ollama directory (models and data)
+	ollamaDir := filepath.Join(homeDir, ".ollama")
+	if err := os.RemoveAll(ollamaDir); err != nil {
+		return fmt.Errorf("failed to remove ~/.ollama: %w", err)
+	}
+
+	return nil
+}
+
+func (i *Installer) findShellConfigsWithConduit(homeDir string) []string {
+	var found []string
+	localBin := filepath.Join(homeDir, ".local", "bin")
+
+	configs := []string{
+		filepath.Join(homeDir, ".zshrc"),
+		filepath.Join(homeDir, ".bashrc"),
+		filepath.Join(homeDir, ".bash_profile"),
+		filepath.Join(homeDir, ".config", "fish", "config.fish"),
+	}
+
+	for _, config := range configs {
+		content, err := os.ReadFile(config)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(content), localBin) || strings.Contains(string(content), "# Conduit") {
+			found = append(found, config)
+		}
+	}
+
+	return found
+}
+
+// cleanupShellConfigSilent removes PATH entries silently and returns files modified.
+func (i *Installer) cleanupShellConfigSilent(homeDir string) []string {
+	var modified []string
+	localBin := filepath.Join(homeDir, ".local", "bin")
+
+	configs := []string{
+		filepath.Join(homeDir, ".zshrc"),
+		filepath.Join(homeDir, ".bashrc"),
+		filepath.Join(homeDir, ".bash_profile"),
+	}
+
+	for _, configPath := range configs {
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			continue
+		}
+
+		lines := strings.Split(string(content), "\n")
+		var newLines []string
+		changed := false
+
+		for j := 0; j < len(lines); j++ {
+			line := lines[j]
+			// Skip the Conduit comment and PATH export lines
+			if strings.Contains(line, "# Conduit") {
+				if j+1 < len(lines) && strings.Contains(lines[j+1], localBin) {
+					j++
+					changed = true
+					continue
+				}
+			}
+			if strings.Contains(line, localBin) && strings.Contains(line, "export PATH") {
+				changed = true
+				continue
+			}
+			newLines = append(newLines, line)
+		}
+
+		if changed {
+			// Clean trailing empty lines
+			for len(newLines) > 0 && newLines[len(newLines)-1] == "" {
+				newLines = newLines[:len(newLines)-1]
+			}
+			newLines = append(newLines, "")
+
+			if err := os.WriteFile(configPath, []byte(strings.Join(newLines, "\n")), 0644); err == nil {
+				modified = append(modified, configPath)
+			}
+		}
+	}
+
+	return modified
+}
+
+func (i *Installer) findConduitSymlinks() []string {
+	var found []string
+	symlinks := []string{
+		"/usr/local/bin/conduit",
+		"/usr/local/bin/conduit-daemon",
+	}
+
+	for _, link := range symlinks {
+		target, err := os.Readlink(link)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(target, ".local/bin") {
+			found = append(found, link)
+		}
+	}
+
+	return found
+}
+
+// cleanupSymlinksSilent removes symlinks silently and returns those removed.
+func (i *Installer) cleanupSymlinksSilent() []string {
+	var removed []string
+	symlinks := i.findConduitSymlinks()
+
+	for _, link := range symlinks {
+		if err := os.Remove(link); err == nil {
+			removed = append(removed, link)
+		}
+	}
+
+	return removed
+}
+
+// PrintUninstallInfo prints uninstall info in a formatted way for CLI.
+func (i *Installer) PrintUninstallInfo(info *UninstallInfo) {
+	fmt.Println()
+	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
+	fmt.Println("║                   Conduit Installation Status                 ║")
+	fmt.Println("╚══════════════════════════════════════════════════════════════╝")
+	fmt.Println()
+
+	// Daemon
+	fmt.Println("Daemon Service:")
+	if info.HasDaemonService {
+		status := "stopped"
+		if info.DaemonRunning {
+			status = "running"
+		}
+		fmt.Printf("  ✓ Installed at %s (%s)\n", info.ServicePath, status)
+	} else {
+		fmt.Println("  ✗ Not installed")
+	}
+
+	// Binaries
+	fmt.Println("\nBinaries:")
+	if info.HasBinaries {
+		if info.ConduitPath != "" {
+			fmt.Printf("  ✓ %s", info.ConduitPath)
+			if info.ConduitVersion != "" {
+				fmt.Printf(" (%s)", info.ConduitVersion)
+			}
+			fmt.Println()
+		}
+		if info.DaemonPath != "" {
+			fmt.Printf("  ✓ %s\n", info.DaemonPath)
+		}
+	} else {
+		fmt.Println("  ✗ Not installed")
+	}
+
+	// Data
+	fmt.Println("\nData Directory:")
+	if info.HasDataDir {
+		fmt.Printf("  ✓ %s (%s)\n", info.DataDirPath, info.DataDirSize)
+		if info.HasConfig {
+			fmt.Println("    ├── conduit.yaml")
+		}
+		if info.HasSQLite {
+			fmt.Println("    └── conduit.db")
+		}
+	} else {
+		fmt.Println("  ✗ Not found")
+	}
+
+	// Containers
+	fmt.Println("\nContainers:")
+	if info.ContainerRuntime != "" {
+		fmt.Printf("  Runtime: %s\n", info.ContainerRuntime)
+		if info.HasQdrantContainer {
+			status := "stopped"
+			if info.QdrantContainerRunning {
+				status = fmt.Sprintf("running, %d vectors", info.QdrantVectorCount)
+			}
+			fmt.Printf("  ✓ conduit-qdrant (%s)\n", status)
+		} else {
+			fmt.Println("  ✗ conduit-qdrant (not found)")
+		}
+		if info.HasFalkorDBContainer {
+			status := "stopped"
+			if info.FalkorDBContainerRunning {
+				status = "running"
+			}
+			fmt.Printf("  ✓ conduit-falkordb (%s)\n", status)
+		} else {
+			fmt.Println("  ✗ conduit-falkordb (not found)")
+		}
+	} else {
+		fmt.Println("  ✗ No container runtime found")
+	}
+
+	// Ollama
+	fmt.Println("\nOllama:")
+	if info.HasOllama {
+		status := "stopped"
+		if info.OllamaRunning {
+			status = "running"
+		}
+		fmt.Printf("  ✓ Installed (%s)\n", status)
+		if len(info.OllamaModels) > 0 {
+			fmt.Printf("    Models: %s\n", strings.Join(info.OllamaModels, ", "))
+		}
+		if info.OllamaSize != "" {
+			fmt.Printf("    Size: %s\n", info.OllamaSize)
+		}
+	} else {
+		fmt.Println("  ✗ Not installed")
+	}
+
+	// Shell config
+	fmt.Println("\nShell Configuration:")
+	if info.HasShellConfig {
+		for _, f := range info.ShellConfigFiles {
+			fmt.Printf("  ✓ PATH export in %s\n", f)
+		}
+	} else {
+		fmt.Println("  ✗ No PATH exports found")
+	}
+
+	// Symlinks
+	fmt.Println("\nSymlinks:")
+	if info.HasSymlinks {
+		for _, s := range info.Symlinks {
+			fmt.Printf("  ✓ %s\n", s)
+		}
+	} else {
+		fmt.Println("  ✗ None found")
+	}
+
+	fmt.Println()
+}


### PR DESCRIPTION
## Summary

Implement a consistent uninstall experience across CLI, script, and Desktop GUI with three uninstall tiers.

### Three Uninstall Tiers

| Tier | Command | What's Removed |
|------|---------|----------------|
| Keep Data | `conduit uninstall --keep-data` | Daemon, binaries, shell config |
| All | `conduit uninstall --all` | + Data directory, containers |
| Full | `conduit uninstall --full --remove-ollama` | + Ollama (optional) |

**Note:** Docker/Podman are **never** removed (system tools).

### New Files

- `internal/installer/uninstall.go` - Core Go uninstall logic with `UninstallWithOptions()`
- `apps/conduit-desktop/src/main/uninstall-ipc.ts` - IPC handlers for Desktop
- `apps/conduit-desktop/src/renderer/components/settings/UninstallPanel.tsx` - GUI component

### Modified Files

- `cmd/conduit/main.go` - Added CLI flags
- `scripts/uninstall.sh` - Delegates to CLI when available
- Desktop app main/preload/SettingsView - Integration

### CLI Flags

```bash
conduit uninstall --keep-data    # Tier 1
conduit uninstall --all          # Tier 2
conduit uninstall --full         # Tier 3
conduit uninstall --force        # Skip confirmations
conduit uninstall --dry-run      # Preview only
conduit uninstall --json         # JSON output
conduit uninstall --info         # Show installation info
conduit uninstall --remove-ollama
conduit uninstall --remove-qdrant
conduit uninstall --remove-falkordb
```

### Key Features

- Single source of truth (Go installer package)
- Bash script delegates to CLI when available
- "UNINSTALL" confirmation required for destructive operations
- Desktop GUI with real-time installation status display

## Test Plan

- [ ] CLI: `conduit uninstall --dry-run` shows correct items
- [ ] CLI: `conduit uninstall --keep-data` preserves data dir
- [ ] CLI: `conduit uninstall --info` displays installation status
- [ ] Script: Delegates to CLI when available
- [ ] GUI: Shows installation status correctly
- [ ] GUI: Tier selection works
- [ ] GUI: Confirmation dialog requires "UNINSTALL"
- [ ] All: Docker/Podman never removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)