### PR TITLE
ci: add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-desktop:
+    strategy:
+      matrix:
+        include:
+          - os: macos-14
+            arch: arm64
+          - os: macos-13
+            arch: x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/conduit-desktop/package-lock.json
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: true
+
+      - name: Get version from tag
+        id: version
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        working-directory: apps/conduit-desktop
+        run: npm ci
+
+      - name: Build and Package DMG
+        working-directory: apps/conduit-desktop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm run package:mac:dmg
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        with:
+          name: dmg-${{ matrix.arch }}
+          path: apps/conduit-desktop/release/${{ steps.version.outputs.VERSION }}/Conduit-*.dmg
+          retention-days: 7
+
+  create-release:
+    needs: build-desktop
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version from tag
+        id: version
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download arm64 DMG
+        uses: actions/download-artifact@v4
+        with:
+          name: dmg-arm64
+          path: ./artifacts/arm64
+
+      - name: Download x64 DMG
+        uses: actions/download-artifact@v4
+        with:
+          name: dmg-x64
+          path: ./artifacts/x64
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            ./artifacts/arm64/*.dmg
+            ./artifacts/x64/*.dmg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds automated DMG builds for macOS releases triggered on version tags.

## What This Does

When you push a tag like `v0.2.0`, this workflow will:

1. **Build DMGs** for both architectures in parallel:
   - `macos-14` runner → arm64 (Apple Silicon)
   - `macos-13` runner → x64 (Intel)

2. **Create a GitHub Release** with both DMGs attached

## Workflow Trigger

```bash
git tag v0.2.0
git push origin v0.2.0
```

## Files Added

- `.github/workflows/release.yml` - GitHub Actions workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)