### PR TITLE
fix(desktop): bundle electron-updater to fix startup crash

### DIFF
--- a/apps/conduit-desktop/electron.vite.config.ts
+++ b/apps/conduit-desktop/electron.vite.config.ts
@@ -4,7 +4,9 @@ import { resolve } from 'path'
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    // Exclude electron-updater from externalization so it gets bundled
+    // This is required because electron-builder excludes node_modules
+    plugins: [externalizeDepsPlugin({ exclude: ['electron-updater'] })],
     build: {
       outDir: 'dist/main',
       rollupOptions: {


### PR DESCRIPTION
## Summary

- Fix critical startup crash caused by missing `electron-updater` module
- Root cause: packaging conflict between electron-vite and electron-builder

## Problem

After installing from the v0.1.0 DMG, the app crashes immediately with:
```
Error: Cannot find module 'electron-updater'
```

**Root Cause:**
| Component | Behavior |
|-----------|----------|
| electron-vite | `externalizeDepsPlugin()` marks all deps as external (not bundled) |
| electron-builder | `files: ["!node_modules/**/*"]` excludes all node_modules |
| Runtime | **CRASH** - `electron-updater` is neither bundled nor packaged |

## Solution

Configure `externalizeDepsPlugin` to **exclude** `electron-updater` from externalization, forcing it to be bundled into the main process output:

```typescript
plugins: [externalizeDepsPlugin({ exclude: ['electron-updater'] })]
```

## Test plan

- [ ] Run `npm run build` - verify build succeeds
- [ ] Run `npm run package:mac:dmg` - verify DMG is created
- [ ] Install DMG on a fresh Mac
- [ ] Run `xattr -cr /Applications/Conduit.app`
- [ ] Open Conduit.app - verify it starts without crash

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)