### PR TITLE
Fix dependency detection and add one-click installation

### DIFF
--- a/apps/conduit-desktop/package.json
+++ b/apps/conduit-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conduit-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Conduit Desktop - AI Intelligence Hub for macOS",
   "author": "Simpleflo",
   "license": "MIT",

--- a/apps/conduit-desktop/src/renderer/components/setup/steps/DependenciesStep.tsx
+++ b/apps/conduit-desktop/src/renderer/components/setup/steps/DependenciesStep.tsx
@@ -10,8 +10,18 @@ import {
   ExternalLink,
   Download,
   RefreshCw,
+  FolderOpen,
+  X,
+  Rocket,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+
+interface InstallProgress {
+  name: string
+  stage: string
+  percent: number
+  message: string
+}
 
 const REQUIRED_DEPENDENCIES: Omit<DependencyStatus, 'installed' | 'version'>[] = [
   {
@@ -19,12 +29,14 @@ const REQUIRED_DEPENDENCIES: Omit<DependencyStatus, 'installed' | 'version'>[] =
     required: true,
     installUrl: 'https://ollama.com/download',
     brewFormula: 'ollama',
+    supportsAutoInstall: true,
   },
   {
     name: 'Docker or Podman',
     required: true,
     installUrl: 'https://podman.io/getting-started/installation',
     brewFormula: 'podman',
+    supportsAutoInstall: true, // Requires Homebrew
   },
 ]
 
@@ -33,6 +45,7 @@ const OPTIONAL_DEPENDENCIES: Omit<DependencyStatus, 'installed' | 'version'>[] =
     name: 'Homebrew',
     required: false,
     installUrl: 'https://brew.sh',
+    supportsAutoInstall: true,
   },
 ]
 
@@ -41,10 +54,30 @@ export function DependenciesStep(): JSX.Element {
 
   const [isChecking, setIsChecking] = useState(true)
   const [isInstalling, setIsInstalling] = useState<string | null>(null)
+  const [isAutoInstalling, setIsAutoInstalling] = useState<string | null>(null)
+  const [installProgress, setInstallProgress] = useState<InstallProgress | null>(null)
+  const [isLocating, setIsLocating] = useState<string | null>(null)
+  const [locateError, setLocateError] = useState<string | null>(null)
 
   // Check dependencies on mount
   useEffect(() => {
     checkDependencies()
+  }, [])
+
+  // Listen for install progress events
+  useEffect(() => {
+    const unsubscribe = window.conduit.onInstallProgress((progress: InstallProgress) => {
+      setInstallProgress(progress)
+      if (progress.stage === 'complete') {
+        // Refresh dependencies after a short delay
+        setTimeout(async () => {
+          await checkDependencies()
+          setIsAutoInstalling(null)
+          setInstallProgress(null)
+        }, 500)
+      }
+    })
+    return unsubscribe
   }, [])
 
   const checkDependencies = async () => {
@@ -90,6 +123,69 @@ export function DependenciesStep(): JSX.Element {
 
   const handleOpenUrl = (url: string) => {
     window.conduit.openExternal(url)
+  }
+
+  const handleLocateManually = async (depName: string) => {
+    setIsLocating(depName)
+    setLocateError(null)
+
+    try {
+      // Open file browser
+      const result = await window.conduit.browseForBinary({ name: depName })
+      if (result.cancelled) {
+        setIsLocating(null)
+        return
+      }
+
+      if (!result.path) {
+        setLocateError('No file selected')
+        setIsLocating(null)
+        return
+      }
+
+      // Validate the selected binary
+      const validation = await window.conduit.validateBinaryPath({ name: depName, binaryPath: result.path })
+      if (!validation.valid) {
+        setLocateError(validation.error || 'Invalid binary')
+        setIsLocating(null)
+        return
+      }
+
+      // Save the custom path
+      const saveResult = await window.conduit.saveCustomPath({ name: depName, binaryPath: result.path })
+      if (!saveResult.success) {
+        setLocateError(saveResult.error || 'Failed to save path')
+        setIsLocating(null)
+        return
+      }
+
+      // Refresh dependencies to pick up the new path
+      await checkDependencies()
+    } catch (error) {
+      setLocateError(`Failed to locate ${depName}: ${error}`)
+    } finally {
+      setIsLocating(null)
+    }
+  }
+
+  const handleAutoInstall = async (depName: string) => {
+    setIsAutoInstalling(depName)
+    setInstallProgress({ name: depName, stage: 'starting', percent: 0, message: 'Starting installation...' })
+    setLocateError(null)
+
+    try {
+      const result = await window.conduit.autoInstallDependency({ name: depName })
+      if (!result.success) {
+        setLocateError(result.error || `Failed to install ${depName}`)
+        setIsAutoInstalling(null)
+        setInstallProgress(null)
+      }
+      // Success will be handled by the progress event listener
+    } catch (error) {
+      setLocateError(`Failed to install ${depName}: ${error}`)
+      setIsAutoInstalling(null)
+      setInstallProgress(null)
+    }
   }
 
   const handleContinue = () => {
@@ -143,11 +239,16 @@ export function DependenciesStep(): JSX.Element {
               return (
                 <DependencyRow
                   key={dep.name}
-                  dependency={{ ...dep, installed: status?.installed || false, version: status?.version }}
+                  dependency={{ ...dep, installed: status?.installed || false, version: status?.version, binaryPath: status?.binaryPath }}
                   isInstalling={isInstalling === dep.name}
+                  isAutoInstalling={isAutoInstalling === dep.name}
+                  installProgress={isAutoInstalling === dep.name ? installProgress : null}
+                  isLocating={isLocating === dep.name}
                   hasHomebrew={hasHomebrew || false}
                   onInstall={() => handleInstall({ ...dep, installed: false })}
+                  onAutoInstall={() => handleAutoInstall(dep.name)}
                   onOpenUrl={() => handleOpenUrl(dep.installUrl!)}
+                  onLocate={() => handleLocateManually(dep.name)}
                 />
               )
             })}
@@ -163,16 +264,41 @@ export function DependenciesStep(): JSX.Element {
               return (
                 <DependencyRow
                   key={dep.name}
-                  dependency={{ ...dep, installed: status?.installed || false, version: status?.version }}
+                  dependency={{ ...dep, installed: status?.installed || false, version: status?.version, binaryPath: status?.binaryPath }}
                   isInstalling={isInstalling === dep.name}
+                  isAutoInstalling={isAutoInstalling === dep.name}
+                  installProgress={isAutoInstalling === dep.name ? installProgress : null}
+                  isLocating={isLocating === dep.name}
                   hasHomebrew={true} // Always show external link for optional
                   onInstall={() => {}}
+                  onAutoInstall={() => handleAutoInstall(dep.name)}
                   onOpenUrl={() => handleOpenUrl(dep.installUrl!)}
+                  onLocate={() => handleLocateManually(dep.name)}
                   isOptional
                 />
               )
             })}
           </div>
+
+          {/* Locate error display */}
+          {locateError && (
+            <div className="p-3 rounded-xl bg-macos-red/10 border border-macos-red/20">
+              <div className="flex items-start gap-3">
+                <XCircle className="w-5 h-5 text-macos-red flex-shrink-0 mt-0.5" />
+                <div className="flex-1">
+                  <p className="text-sm text-macos-text-primary dark:text-macos-text-dark-primary">
+                    {locateError}
+                  </p>
+                </div>
+                <button
+                  onClick={() => setLocateError(null)}
+                  className="text-macos-text-tertiary hover:text-macos-text-primary"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Refresh button */}
           <button
@@ -230,22 +356,60 @@ export function DependenciesStep(): JSX.Element {
 }
 
 interface DependencyRowProps {
-  dependency: DependencyStatus
+  dependency: DependencyStatus & { supportsAutoInstall?: boolean }
   isInstalling: boolean
+  isAutoInstalling: boolean
+  installProgress: InstallProgress | null
+  isLocating: boolean
   hasHomebrew: boolean
   onInstall: () => void
+  onAutoInstall: () => void
   onOpenUrl: () => void
+  onLocate: () => void
   isOptional?: boolean
 }
 
 function DependencyRow({
   dependency,
   isInstalling,
+  isAutoInstalling,
+  installProgress,
+  isLocating,
   hasHomebrew,
   onInstall,
+  onAutoInstall,
   onOpenUrl,
+  onLocate,
   isOptional,
 }: DependencyRowProps): JSX.Element {
+  const isAnyOperationActive = isInstalling || isAutoInstalling || isLocating
+
+  // Show progress bar when auto-installing
+  if (isAutoInstalling && installProgress) {
+    return (
+      <div className="p-3 rounded-xl border border-macos-blue/20 bg-macos-blue/5">
+        <div className="flex items-center gap-3 mb-2">
+          <Loader2 className="w-5 h-5 animate-spin text-macos-blue flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="font-medium text-macos-text-primary dark:text-macos-text-dark-primary">
+              {dependency.name}
+            </p>
+            <p className="text-xs text-macos-text-secondary dark:text-macos-text-dark-secondary">
+              {installProgress.message}
+            </p>
+          </div>
+        </div>
+        {/* Progress bar */}
+        <div className="h-1.5 bg-macos-bg-tertiary dark:bg-macos-bg-dark-tertiary rounded-full overflow-hidden">
+          <div
+            className="h-full bg-macos-blue rounded-full transition-all duration-300"
+            style={{ width: `${installProgress.percent}%` }}
+          />
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div
       className={cn(
@@ -274,18 +438,69 @@ function DependencyRow({
         {dependency.installed && dependency.version && (
           <p className="text-xs text-macos-text-tertiary">{dependency.version}</p>
         )}
+        {dependency.installed && dependency.binaryPath && (
+          <p className="text-xs text-macos-text-tertiary truncate" title={dependency.binaryPath}>
+            {dependency.binaryPath}
+          </p>
+        )}
       </div>
 
-      {/* Action button */}
+      {/* Action buttons */}
       {!dependency.installed && (
         <div className="flex items-center gap-2">
-          {hasHomebrew && dependency.brewFormula ? (
+          {/* Locate button - always show for non-optional deps */}
+          {!isOptional && (
             <button
-              onClick={onInstall}
-              disabled={isInstalling}
+              onClick={onLocate}
+              disabled={isAnyOperationActive}
               className={cn(
                 'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
-                isInstalling
+                isAnyOperationActive
+                  ? 'bg-macos-bg-tertiary text-macos-text-tertiary cursor-not-allowed'
+                  : 'bg-macos-bg-tertiary dark:bg-macos-bg-dark-tertiary text-macos-text-primary dark:text-macos-text-dark-primary hover:bg-macos-bg-secondary dark:hover:bg-macos-bg-dark-secondary'
+              )}
+              title="Locate the binary manually if auto-detection fails"
+            >
+              {isLocating ? (
+                <>
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  Locating...
+                </>
+              ) : (
+                <>
+                  <FolderOpen className="w-3.5 h-3.5" />
+                  Locate
+                </>
+              )}
+            </button>
+          )}
+
+          {/* Auto-install button (primary action) */}
+          {dependency.supportsAutoInstall && (
+            <button
+              onClick={onAutoInstall}
+              disabled={isAnyOperationActive}
+              className={cn(
+                'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
+                isAnyOperationActive
+                  ? 'bg-macos-bg-tertiary text-macos-text-tertiary cursor-not-allowed'
+                  : 'bg-macos-blue text-white hover:bg-macos-blue/90'
+              )}
+              title="Automatically download and install"
+            >
+              <Rocket className="w-3.5 h-3.5" />
+              Auto Install
+            </button>
+          )}
+
+          {/* Manual install via Homebrew - show as secondary option if Homebrew available */}
+          {hasHomebrew && dependency.brewFormula && !dependency.supportsAutoInstall && (
+            <button
+              onClick={onInstall}
+              disabled={isAnyOperationActive}
+              className={cn(
+                'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
+                isAnyOperationActive
                   ? 'bg-macos-bg-tertiary text-macos-text-tertiary cursor-not-allowed'
                   : 'bg-macos-blue text-white hover:bg-macos-blue/90'
               )}
@@ -302,15 +517,23 @@ function DependencyRow({
                 </>
               )}
             </button>
-          ) : (
-            <button
-              onClick={onOpenUrl}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-macos-bg-tertiary dark:bg-macos-bg-dark-tertiary text-macos-text-primary dark:text-macos-text-dark-primary hover:bg-macos-bg-secondary dark:hover:bg-macos-bg-dark-secondary transition-colors"
-            >
-              <ExternalLink className="w-3.5 h-3.5" />
-              Download
-            </button>
           )}
+
+          {/* Download link - always available as fallback */}
+          <button
+            onClick={onOpenUrl}
+            disabled={isAnyOperationActive}
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
+              isAnyOperationActive
+                ? 'bg-macos-bg-tertiary text-macos-text-tertiary cursor-not-allowed'
+                : 'bg-macos-bg-tertiary dark:bg-macos-bg-dark-tertiary text-macos-text-primary dark:text-macos-text-dark-primary hover:bg-macos-bg-secondary dark:hover:bg-macos-bg-dark-secondary'
+            )}
+            title="Open download page in browser"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            Download
+          </button>
         </div>
       )}
     </div>

--- a/apps/conduit-desktop/src/renderer/stores/setup.ts
+++ b/apps/conduit-desktop/src/renderer/stores/setup.ts
@@ -16,6 +16,9 @@ export interface DependencyStatus {
   required: boolean
   installUrl?: string
   brewFormula?: string
+  binaryPath?: string       // Path where the binary was found
+  customPath?: string       // User-specified custom path (if any)
+  supportsAutoInstall?: boolean  // Whether auto-installation is supported
 }
 
 export interface SetupState {


### PR DESCRIPTION
## Summary

- Fixes dependency detection for Homebrew-installed binaries (Ollama, Docker, Podman)
- Adds manual path specification UI with "Locate" button
- Adds one-click auto-installation with progress tracking

## Problem

Electron apps don't inherit shell PATH from `~/.zshrc`/`~/.bashrc`, so Homebrew paths like `/opt/homebrew/bin` (Apple Silicon) or `/usr/local/bin` (Intel) aren't searched when detecting dependencies.

## Solution

### Phase 1: Fix Detection Logic
- Added `KNOWN_PATHS` constant with common installation locations
- Created `findBinary()` helper that checks: custom paths → known paths → PATH
- Updated all dependency detection to use `findBinary()`

### Phase 2: Manual Path Specification
- Added "Locate" button to browse for binaries manually
- Implemented IPC handlers for path validation, saving, and clearing
- Custom paths persist in `custom-paths.json` in app userData

### Phase 3: One-Click Auto-Installation
- Added "Auto Install" button with progress bar UI
- Ollama: Uses official installer script (`curl -fsSL https://ollama.com/install.sh | sh`)
- Podman: Uses Homebrew (`brew install podman`)
- Homebrew: Opens Terminal with official installer

## Files Changed

| File | Changes |
|------|---------|
| `src/main/setup-ipc.ts` | Added `KNOWN_PATHS`, `findBinary()`, custom path persistence, auto-install handlers |
| `src/preload/index.ts` | Added `autoInstallDependency`, `onInstallProgress`, updated types |
| `src/renderer/stores/setup.ts` | Extended `DependencyStatus` type |
| `src/renderer/components/setup/steps/DependenciesStep.tsx` | Added auto-install UI with progress bar |
| `package.json` | Bumped version to 0.1.1 |

## Test Plan

- [ ] Install Ollama via Homebrew, verify it's detected in setup wizard
- [ ] Install Podman via Homebrew, verify it's detected in setup wizard
- [ ] Test "Locate" button to manually specify a binary path
- [ ] Test "Auto Install" button for Ollama installation
- [ ] Test "Auto Install" button for Podman installation (requires Homebrew)
- [ ] Verify progress bar shows during installation
- [ ] Verify dependencies refresh after installation

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)