### PR TITLE
fix: credential helper bypass and simplified uninstall

### DIFF
--- a/apps/conduit-desktop/package.json
+++ b/apps/conduit-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conduit-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Conduit Desktop - AI Intelligence Hub for macOS",
   "author": "Simpleflo",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Fixes two critical issues found during remote testing:

### Issue #27: Container Image Pull Fails with gcloud Credential Helper
**Problem**: When users have Google Cloud SDK installed with Docker credential helper configured, Podman fails to pull public images with "docker-credential-gcloud not found" error.

**Solution**: 
- Add `--authfile /dev/null` flag for Podman when pulling images to bypass credential helpers
- For Docker, set `DOCKER_CONFIG` environment variable to skip credential lookup
- Our images (qdrant/qdrant, falkordb/falkordb) are public and don't require authentication

### Issue #28: Simplified Uninstall - Remove Dependency Management
**Problem**: The uninstall command tried to manage containers and Ollama removal, causing confusing errors when these didn't exist, and risking removal of shared dependencies.

**Solution**:
- Remove container (Qdrant, FalkorDB) removal from uninstall
- Remove Ollama removal from uninstall  
- Add clear manual cleanup instructions in output
- Simplify from 3 tiers to 2 (keep-data vs remove-all)
- Make uninstall more resilient (don't report non-existent items as failures)

## Test plan
- [ ] Verify container images can be pulled with gcloud credential helper configured
- [ ] Verify uninstall completes without errors when dependencies don't exist
- [ ] Verify manual cleanup instructions are displayed after uninstall

## Files changed
- `apps/conduit-desktop/src/main/setup-ipc.ts` - Add credential bypass for image pulls
- `cmd/conduit/main.go` - Simplify uninstall command
- `internal/installer/uninstall.go` - Remove container/Ollama management
- `scripts/uninstall.sh` - Simplify bash uninstall script
- `apps/conduit-desktop/package.json` - Version bump to 0.1.3

Closes #27, Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)